### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - stage: test-build
       skip_cleanup: true
-      script: go build -o webp-server-linux-amd64 webp-server.go
+      script: make
       script: ls
 
     - stage: GitHub Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,21 @@ language: go
 go: 
  - 1.13
 
-jobs:
-  include:
-    - stage: test-build
-      skip_cleanup: true
-      script: make
-      script: ls
+before_install:
+  - go get github.com/mitchellh/gox
 
-    - stage: GitHub Release
-      script: echo "Deploying to GitHub releases ..."
-      deploy:
-        provider: releases
-        api_key: $GITHUB_OAUTH_TOKEN
-        skip_cleanup: true
-        file:
-            - webp-server
-        on:
-            repo: webp-sh/webp_server_go
-            tags: false
-            branch: add-travis-ci
+script: echo "Deploying to GitHub releases ..."
+script: gox -os="linux darwin windows" -arch="amd64" -output="webp-server.." -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  skip_cleanup: true
+  file:
+      - webp-server.linux.amd64
+      - webp-server.darwin.amd64
+      - webp-server.windows.amd64.exe
+  on:
+      repo: webp-sh/webp_server_go
+      tags: false
+      branch: add-travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - go get github.com/mitchellh/gox
 
 script: echo "Deploying to GitHub releases ..."
-script: gox -os="linux darwin windows" -arch="amd64" -output="webp-server.." -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...
+script: gox -os="linux darwin windows" -arch="amd64" -output="webp-server.."
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ go:
 jobs:
   include:
     - stage: test-build
-      script: go build
+      script: go build -o webp-server-linux-amd64 webp-server.go
+      script: ls
 
     - stage: GitHub Release
       script: echo "Deploying to GitHub releases ..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ go:
 env: GO111MODULE=on
 
 script: GOARCH=amd64 go build -o webp-server-linux-amd64 webp-server.go
-script: GOOS=windows GOARCH=amd64 go build -o webp-server-windows-amd64.exe webp-server.go
-script: GOOS=darwin GOARCH=amd64 go build -o webp-server-darwin-amd64.exe webp-server.go
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ go:
  
 env: GO111MODULE=on
 
-script: go build -o webp-server webp-server.go
+script: GOARCH=amd64 go build -o webp-server-linux-amd64 webp-server.go
+script: GOOS=windows GOARCH=amd64 go build -o webp-server-windows-amd64.exe webp-server.go
+script: GOOS=darwin GOARCH=amd64 go build -o webp-server-darwin-amd64.exe webp-server.go
 
 deploy:
   provider: releases
@@ -15,5 +17,5 @@ deploy:
       - webp-server
   on:
       repo: webp-sh/webp_server_go
-      tags: false
+      tags: true
       branch: add-travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,19 @@ language: go
 go: 
  - 1.13
 
-script:
- - go build
+jobs:
+    include:
+        - stage: test-build
+          script: go build
+
+          - stage: GitHub Release
+            script: echo "Deploying to GitHub releases ..."
+            deploy:
+                provider: releases
+                api_key: $GITHUB_OAUTH_TOKEN
+                skip_cleanup: true
+                file:
+                    - webp-server
+                on:
+                    repo: webp-sh/webp_server_go
+                    tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ go:
  - 1.13
 
 jobs:
-    include:
-        - stage: test-build
-          script: go build
+  include:
+    - stage: test-build
+      script: go build
 
-          - stage: GitHub Release
-            script: echo "Deploying to GitHub releases ..."
-            deploy:
-                provider: releases
-                api_key: $GITHUB_OAUTH_TOKEN
-                skip_cleanup: true
-                file:
-                    - webp-server
-                on:
-                    repo: webp-sh/webp_server_go
-                    tags: false
+    - stage: GitHub Release
+      script: echo "Deploying to GitHub releases ..."
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        skip_cleanup: true
+        file:
+            - webp-server
+        on:
+            repo: webp-sh/webp_server_go
+            tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ deploy:
   api_key: $GITHUB_OAUTH_TOKEN
   skip_cleanup: true
   file:
-      - webp-server
+      - webp-server-linux-amd64
   on:
       repo: webp-sh/webp_server_go
       tags: true
-      branch: add-travis-ci
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,14 @@ go:
  
 env: GO111MODULE=on
 
-before_install:
-  - go get github.com/mitchellh/gox
-
-script: echo "Deploying to GitHub releases ..."
-script: gox -os="linux darwin windows" -arch="amd64" -output="webp-server.."
+script: go build -o webp-server webp-server.go
 
 deploy:
   provider: releases
   api_key: $GITHUB_OAUTH_TOKEN
   skip_cleanup: true
   file:
-      - webp-server.linux.amd64
-      - webp-server.darwin.amd64
-      - webp-server.windows.amd64.exe
+      - webp-server
   on:
       repo: webp-sh/webp_server_go
       tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 jobs:
   include:
     - stage: test-build
+      skip_cleanup: true
       script: go build -o webp-server-linux-amd64 webp-server.go
       script: ls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ jobs:
         on:
             repo: webp-sh/webp_server_go
             tags: false
+            branch: add-travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go: 
  - 1.13
+ 
+env: GO111MODULE=on
 
 before_install:
   - go get github.com/mitchellh/gox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+BINARY_NAME=webp-server
+BINARY_LINUX=$(BINARY_NAME)_linux-amd64
+
+all: test build
+build: 
+		$(GOBUILD) -o $(BINARY_NAME) -v
+test: 
+		$(GOTEST) -v ./...

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ GOGET=$(GOCMD) get
 BINARY_NAME=webp-server
 BINARY_LINUX=$(BINARY_NAME)_linux-amd64
 
-all: test build
+all: build
 build: 
-		$(GOBUILD) -o $(BINARY_NAME) -v
+		$(GOBUILD) -o $(BINARY_LINUX) -v
 test: 
 		$(GOTEST) -v ./...


### PR DESCRIPTION
This would automatically build on Travis-CI, and push the `linux-amd64` version of `webp-server` to release.

TODO:
* Custom TAG name on release
* Build on multiple arch(darwin and windows)