### PR TITLE
Use goroutine for prefetch

### DIFF
--- a/webp-server.go
+++ b/webp-server.go
@@ -229,7 +229,7 @@ func prefetchImages(confImgPath string, QUALITY string) {
 				_, p2 := genWebpAbs(picAbsPath, info.Name(), proposedURI)
 				q, _ := strconv.ParseFloat(QUALITY, 32)
 				_ = os.MkdirAll(path.Dir(p2), os.ModePerm)
-				_ = webpEncoder(picAbsPath, p2, float32(q), false)
+				go webpEncoder(picAbsPath, p2, float32(q), false)
 				count += 1
 				// progress bar
 				_, _ = fmt.Fprintf(os.Stdout, "Convert in progress: %d/%d\r", count, all)


### PR DESCRIPTION
So we could use all cores on `--prefetch` mode.
![photo_2020-02-29_18-50-00](https://user-images.githubusercontent.com/24852034/75606188-3c314180-5b25-11ea-9fe2-699132e46bb1.jpg)
