### PR TITLE
auto update in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ It's basically between `ExpressJS` and `Fiber`, much faster than the `http` pack
 * `webp_server`: Clone the repo -> `npm install` -> run with `pm2`
 * `webp-server(go)`: Download a single binary -> Run
 
+### Auto update
+This tool will check for new release whenever you run it. The updated binary will be save to `update` dir.
 
 ## General Usage Steps
 Regarding the `IMG_PATH` section in `config.json`. 

--- a/webp-server.go
+++ b/webp-server.go
@@ -313,10 +313,56 @@ func prefetchImages(confImgPath string, ExhaustPath string, QUALITY string) {
 	_, _ = fmt.Fprintf(os.Stdout, "Prefetch completeY(^_^)Y\n\n")
 
 }
+func autoUpdate() {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println("Download error.", err)
+		}
+	}()
+
+	var api = "https://api.github.com/repos/webp-sh/webp_server_go/releases/latest"
+	type Result struct {
+		TagName string `json:"tag_name"`
+	}
+	var res Result
+	resp1, _ := http.Get(api)
+	data1, _ := ioutil.ReadAll(resp1.Body)
+	_ = json.Unmarshal(data1, &res)
+
+	var gitVersion = res.TagName
+
+	if gitVersion > version {
+		log.Printf("Time to update! New version %s found!", gitVersion)
+	} else {
+		log.Println("No new version found.")
+		return
+	}
+
+	var filename = fmt.Sprintf("webp-server-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOARCH == "windows" {
+		filename += ".exe"
+	}
+	var releaseUrl = "https://github.com/webp-sh/webp_server_go/releases/latest/download/" + filename
+	log.Println("Downloading binary...")
+	resp, _ := http.Get(releaseUrl)
+	if resp.StatusCode != 200 {
+		log.Printf("%s-%s not found on release. "+
+			"Contact developers to supply your version", runtime.GOOS, runtime.GOARCH)
+		return
+	}
+	data, _ := ioutil.ReadAll(resp.Body)
+	_ = os.Mkdir("update", 0755)
+	err := ioutil.WriteFile(path.Join("update", filename), data, 0755)
+
+	if err == nil {
+		log.Println("Update complete. Please find your binary from update directory.")
+	}
+	_ = resp.Body.Close()
+}
 
 func main() {
+	go autoUpdate()
 	config := loadConfig(configPath)
-
 	HOST := config.HOST
 	PORT := config.PORT
 	confImgPath := path.Clean(config.ImgPath)


### PR DESCRIPTION
auto update function when start/restart webp-server, async, one-time

will check for the latest release tag, download to `update` folder.

**release file name should be webp-server-GOOS-GOARCH**

one test case: untag release, but no macOS release.

![image](https://user-images.githubusercontent.com/14024832/75786487-5aef3c80-5da0-11ea-98b9-ef96bab39b0b.png)
