### PR TITLE
switch to github.com/webp-sh/webp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/gofiber/fiber v1.4.0
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1
 )
+
+replace github.com/chai2010/webp v1.1.0 => github.com/webp-sh/webp v1.1.0


### PR DESCRIPTION
Hi guys,

I've switch to github.com/webp-sh/webp instead of github.com/chai2010/webp

* using replace directive to replace, version number stays the same
* delete libwebp 0.0.5 and unknown version
* upgrade libwebp from 1.0.1 to 1.1.0

My tests seem ok, the conversion is good, and even the converted files stay exactly the same size( not even one byte change)

Please test performance(time consuming, cpu consuming), stability and compatibility of this branch.

If you want to switch to original chai2010/webp, just remove `replace github.com/chai2010/webp v1.1.0 => github.com/webp-sh/webp v1.1.0` in `go.mod`
if you want our version of webp, just add this line

**before use and any switches, I would recommend you to delete `go/mod/pkg/github/chai2010` and `go/mod/pkg/github/web-sh`**

