### PR TITLE
Suport multiple server names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ exhaust/
 /.idea/modules.xml
 /.idea/vcs.xml
 /.idea/webp_server_go.iml
+
+config-example.json

--- a/config.go
+++ b/config.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+    "encoding/json"
+    "os"
+	"fmt"
+	"path"
+	"errors"
+)
+
+type JsonConfig struct {
+	HOST         string
+	PORT         string
+	ImgPath      string `json:"IMG_PATH"`
+	QUALITY      string
+	AllowedTypes []string `json:"ALLOWED_TYPES"`
+	ExhaustPath  string   `json:"EXHAUST_PATH"`
+	EXTRA        []ExtraConfig
+}
+
+type Config struct {
+	HOST         string
+	PORT         string
+	ImgPath      string `json:"IMG_PATH"`
+	QUALITY      string
+	AllowedTypes []string `json:"ALLOWED_TYPES"`
+	ExhaustPath  string   `json:"EXHAUST_PATH"`
+	EXTRA        map[string]ExtraConfig
+}
+
+type ExtraConfig struct {
+	ServerName      string `json:"SERVER_NAME"`
+	ImgPath         string `json:"IMG_PATH"`
+	ExhaustPath     string `json:"EXHAUST_PATH"`
+}
+
+func LoadConfig(path string) (Config,error){
+	var jconfig JsonConfig
+	var config Config
+	var err error
+    filePtr, _ := os.Open(path)
+    defer filePtr.Close()
+ 
+    decoder := json.NewDecoder(filePtr)
+ 
+    errs := decoder.Decode(&jconfig)
+    if errs!=nil{
+        err = errors.New("error:read config file fail")
+	}
+	config.HOST = jconfig.HOST
+	config.PORT = jconfig.PORT
+	config.QUALITY = jconfig.QUALITY
+	config.AllowedTypes = jconfig.AllowedTypes
+	config.ImgPath = jconfig.ImgPath
+	config.ExhaustPath = jconfig.ExhaustPath
+
+	if jconfig.EXTRA == nil {
+		config.EXTRA = nil;
+	}else{
+		config.EXTRA = make(map[string]ExtraConfig)
+		for _,value := range jconfig.EXTRA{
+			config.EXTRA[value.ServerName] = value
+		}
+	}
+	fmt.Println(config)
+	return config,err
+}
+
+
+func (config *Config)GetExhaustPath(serverName string) (exhaustPath string,err error){
+	if config.EXTRA == nil{
+		if len(config.ExhaustPath) == 0{
+			exhaustPath = "./exhaust"
+		}else{
+			exhaustPath = path.Clean(config.ExhaustPath)
+		}
+	}else{
+		if value,exist := config.EXTRA[serverName]; exist{
+			if len(value.ExhaustPath) == 0{
+				exhaustPath = "./exhaust"
+			}else{
+				exhaustPath = path.Clean(value.ExhaustPath)
+			}
+		}else{
+			err = errors.New("error: server name is not exist")
+			exhaustPath = ""
+			return 
+		}
+	}
+	return 	
+}
+
+func (config *Config)GetImagePath(serverName string)  string{
+	if config.EXTRA == nil{
+		return config.ImgPath
+	}else{
+		return path.Clean(config.EXTRA[serverName].ImgPath)
+	}
+}
+
+func (config *Config)GetAllImagePathAndExhaustPath() []ExtraConfig{
+	all := make([]ExtraConfig,0)
+	if config.EXTRA == nil{
+		if len(config.ExhaustPath) == 0 {
+			config.ExhaustPath = "./exhaust"
+		}
+		single :=ExtraConfig{
+			ImgPath : config.ImgPath,
+			ExhaustPath : config.ExhaustPath,
+		}
+		all = append(all,single)
+	}else{
+		for _, v := range config.EXTRA {
+			if len(v.ExhaustPath) == 0 {
+				v.ExhaustPath = "./exhaust"
+			}
+			single :=ExtraConfig{
+				ImgPath : v.ImgPath,
+				ExhaustPath : v.ExhaustPath,
+			}
+			all = append(all,single)
+		}
+	}
+	return all
+}
+
+// func main(){
+// 	config,_ := LoadConfig("./config-example.json")
+// 	// // for k,v := range config.GetAllImagePathAndExhaustPath(){
+// 	// // 	fmt.Println(k)
+// 	// // 	fmt.Println(v.ImgPath)
+// 	// // 	fmt.Println(v.ExhaustPath)
+// 	// // }
+// 	fmt.Println(config.GetExhaustPath("webptest2.keshane.moe"))
+// }

--- a/config.json
+++ b/config.json
@@ -2,7 +2,19 @@
   "HOST": "127.0.0.1",
   "PORT": "3333",
   "QUALITY": "80",
-  "IMG_PATH": "/path/to/pics",
+  "IMG_PATH": "/path/to/pics/",
   "EXHAUST_PATH": "",
-  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","gif"]
+  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","gif"],
+  "EXTRA":[
+    {
+      "SERVER_NAME":"your.server.name1",
+      "IMG_PATH":"/path/to/pics1/",
+      "EXHAUST_PATH":"/path/to/pics2.ex/"
+    },
+    {
+      "SERVER_NAME":"your.server.name2",
+      "IMG_PATH":"/path/to/pics2",
+      "EXHAUST_PATH":"/path/to/pics2.ex/"
+    }
+  ]
 }

--- a/router.go
+++ b/router.go
@@ -13,9 +13,107 @@ import (
 
 func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY string) func(c *fiber.Ctx) {
 	return func(c *fiber.Ctx) {
-		log.Infof("innder Convert")
-		log.Infof("exhaust path : %s",ExhaustPath)
 		//basic vars
+		var reqURI = c.Path()                        // mypic/123.jpg
+		var RawImageAbs = path.Join(ImgPath, reqURI) // /home/xxx/mypic/123.jpg
+		var ImgFilename = path.Base(reqURI)          // pure filename, 123.jpg
+		var finalFile string                         // We'll only need one c.sendFile()
+		// Check for Safari users. If they're Safari, just simply ignore everything.
+		UA := c.Get("User-Agent")
+		if strings.Contains(UA, "Safari") && !strings.Contains(UA, "Chrome") &&
+			!strings.Contains(UA, "Firefox") {
+			log.Info("A Safari use has arrived...")
+			c.SendFile(RawImageAbs)
+			return
+		}
+		log.Debugf("Incoming connection from %s@%s with %s", UA, c.IP(), ImgFilename)
+
+		// check ext
+		// TODO: may remove this function. Check in Nginx.
+		var allowed = false
+		for _, ext := range AllowedTypes {
+			haystack := strings.ToLower(ImgFilename)
+			needle := strings.ToLower("." + ext)
+			if strings.HasSuffix(haystack, needle) {
+				allowed = true
+				break
+			} else {
+				allowed = false
+			}
+		}
+		if !allowed {
+			msg := "File extension not allowed! " + ImgFilename
+			log.Warn(msg)
+			c.Send(msg)
+			if ImageExists(RawImageAbs) {
+				c.SendFile(RawImageAbs)
+			}
+			return
+		}
+
+		// Check the original image for existence,
+		if !ImageExists(RawImageAbs) {
+			msg := "Image not found!"
+			c.Send(msg)
+			log.Warn(msg)
+			c.SendStatus(404)
+			return
+		}
+
+		_, WebpAbsPath := GenWebpAbs(RawImageAbs, ExhaustPath, ImgFilename, reqURI)
+
+		if ImageExists(WebpAbsPath) {
+			finalFile = WebpAbsPath
+		} else {
+			// we don't have abc.jpg.png1582558990.webp
+			// delete the old pic and convert a new one.
+			// /home/webp_server/exhaust/path/to/tsuki.jpg.1582558990.webp
+			destHalfFile := path.Clean(path.Join(WebpAbsPath, path.Dir(reqURI), ImgFilename))
+			matches, err := filepath.Glob(destHalfFile + "*")
+			if err != nil {
+				log.Error(err.Error())
+			} else {
+				// /home/webp_server/exhaust/path/to/tsuki.jpg.1582558100.webp <- older ones will be removed
+				// /home/webp_server/exhaust/path/to/tsuki.jpg.1582558990.webp <- keep the latest one
+				for _, p := range matches {
+					if strings.Compare(destHalfFile, p) != 0 {
+						_ = os.Remove(p)
+					}
+				}
+			}
+
+			//for webp, we need to create dir first
+			_ = os.MkdirAll(path.Dir(WebpAbsPath), 0755)
+			q, _ := strconv.ParseFloat(QUALITY, 32)
+			err = WebpEncoder(RawImageAbs, WebpAbsPath, float32(q), true, nil)
+
+			if err != nil {
+				log.Error(err)
+				c.SendStatus(400)
+				c.Send("Bad file!")
+				return
+			}
+			finalFile = WebpAbsPath
+		}
+		c.SendFile(finalFile)
+	}
+}
+
+func CConvert(config Config) func(c *fiber.Ctx) {
+	return func(c *fiber.Ctx) {
+		s := strings.Split(c.Get("host"),"/")
+		serverName := s[len(s)-1]
+		ExhaustPath,err := config.GetExhaustPath(serverName)
+		if err != nil{
+			log.Warn("error: server name is not exist")
+		}
+		log.Debugf("Get request server name %s",serverName)
+		log.Debugf("exhaust path : %s",ExhaustPath)
+		log.Debugf("image path : %s",config.GetImagePath(serverName))
+		AllowedTypes := config.AllowedTypes 
+		QUALITY := config.QUALITY
+		ImgPath := config.GetImagePath(serverName)
+
 		var reqURI = c.Path()                        // mypic/123.jpg
 		var RawImageAbs = path.Join(ImgPath, reqURI) // /home/xxx/mypic/123.jpg
 		var ImgFilename = path.Base(reqURI)          // pure filename, 123.jpg

--- a/router.go
+++ b/router.go
@@ -13,6 +13,8 @@ import (
 
 func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY string) func(c *fiber.Ctx) {
 	return func(c *fiber.Ctx) {
+		log.Infof("innder Convert")
+		log.Infof("exhaust path : %s",ExhaustPath)
 		//basic vars
 		var reqURI = c.Path()                        // mypic/123.jpg
 		var RawImageAbs = path.Join(ImgPath, reqURI) // /home/xxx/mypic/123.jpg

--- a/webp-server.go
+++ b/webp-server.go
@@ -1,14 +1,10 @@
 package main
 
 import (
-	// "encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	// "path"
 	"runtime"
-	"strings"
-
 	"github.com/gofiber/fiber"
 	log "github.com/sirupsen/logrus"
 )
@@ -115,19 +111,26 @@ func main() {
 	// Server Info
 	log.Infof("WebP Server %s %s", version, ListenAddress)
 
-	app.Get("/*", func(c *fiber.Ctx) {
-		s := strings.Split(c.Get("host"),"/")
-		serverName := s[len(s)-1]
-		exhaustPath,err := config.GetExhaustPath(serverName)
-		if err != nil{
-			log.Infof("error: server name is not exist")
-		}
-		log.Infof("Get request server name %s",serverName)
-		log.Infof("exhaust path : %s",exhaustPath)
-		log.Infof("image path : %s",config.GetImagePath(serverName))
-		log.Infof("invoke Convert")
-		Convert(config.GetImagePath(serverName),exhaustPath , config.AllowedTypes, config.QUALITY)
-	  })
+	//I don't know why no effect
+	// var ServerName string
+	// var ExhaustPath string
+	// app.Use(func(c *fiber.Ctx){
+	// 	s := strings.Split(c.Get("host"),"/")
+	// 	ServerName = s[len(s)-1]
+	// 	exhaust,err := config.GetExhaustPath(ServerName)
+	// 	ExhaustPath = exhaust
+	// 	if err != nil{
+	// 		log.Warn("error: server name is not exist")
+	// 	}
+	// 	log.Infof("Get request server name %s",ServerName)
+	// 	log.Infof("exhaust path : %s",ExhaustPath)
+	// 	log.Infof("image path : %s",config.GetImagePath(ServerName))
+	// 	c.Next()
+	// })
+
+	// app.Get("/*", Convert(config.GetImagePath(ServerName),ExhaustPath , config.AllowedTypes, config.QUALITY))
+
+	app.Get("/*", CConvert(config))
 	app.Listen(ListenAddress)
 
 }


### PR DESCRIPTION
Hey !
I've implemented a new feature that suport multiple server names. In order to implement this feature, I separate `config.go` from `webp-server.go`. If people want to multiple server name support, they need to create their config file like 
```
{
  "HOST": "127.0.0.1",
  "PORT": "3333",
  "QUALITY": "80",
  "IMG_PATH": "/path/to/pics/",
  "EXHAUST_PATH": "",
  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","gif"],
  "EXTRA":[
    {
      "SERVER_NAME":"your.server.name1",
      "IMG_PATH":"/path/to/pics1/",
      "EXHAUST_PATH":"/path/to/pics2/.ex/"
    },
    {
      "SERVER_NAME":"your.server.name2",
      "IMG_PATH":"/path/to/pics2",
      "EXHAUST_PATH":"/path/to/pics2/.ex/"
    }
  ]
}
```
and add host to header in nginx.
Of course they can use new version with out modify `config.json` if they don't write the "EXTRA" in config file, it will works like old way.

I've tested in my server, it works well in two ways, but I think it would have performance loss and I don't have enviroment to test, please test performance and then merge it. 