### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine as builder
+RUN apk update ;\
+    apk add alpine-sdk ;\
+    git clone https://github.com/webp-sh/webp_server_go /build ;\
+    cd /build ;\
+    sed -i 's/\/path\/to\/exhaust/\/opt\/exhaust/g' config.json ;\
+    sed -i 's/\/path\/to\/pics/\/opt\/pics/g' config.json ;\
+    sed -i 's/127.0.0.1/0.0.0.0/g' config.json
+WORKDIR /build
+RUN go build -o webp-server .
+FROM alpine
+COPY --from=builder /build/webp-server  /usr/bin/webp-server
+COPY --from=builder /build/config.json /etc/config.json
+WORKDIR /opt
+VOLUME /opt/exhaust
+CMD ["/usr/bin/webp-server", "--config", "/etc/config.json"]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ systemctl daemon-reload
 systemctl enable webp-server.service
 systemctl start webp-server.service
 ```
+
+#### docker
+
+We've build docker images on [hub.docker.com](https://hub.docker.com/repository/docker/webpsh/webps). If you want to run webp-server insider docker container, you can run the command below,
+```shell
+docker run -d -p 3333:3333 -v /path/to/pics:/opt/pics --name webps webpsh/webps
+```
+The path `path/to/pics` is your images serving in local. The path `/opt/pics` unable modify because it define in the `config.json` when building docker image. The cache folder of `EXHAUST_PATH` default define in `/opt/exhaust` , you can also mount the local dir for the cache folder by using `-v /path/to/exhaust:/opt/exhaust` option.
+
 ### 4. Nginx proxy_pass
 Let Nginx to `proxy_pass http://localhost:3333/;`, and your webp-server is on-the-fly
 #### WordPress example


### PR DESCRIPTION
Hi guys,

 I’ve add Dockerfile for webp_server_go 

-   only `20.5MB` 
-   using golang:alpine as builder image
-   using alpine:latest  as base image
-   using master branch as source for building

My tests of using docker seem ok, the conversion in docker container is good.

When useing docker can run the command

```shell
docker run -d -p 3333:3333 -v /path/to/pics:/opt/pics --name webps webpsh/webps
```

 `/path/to/pics` is the local `IMG_PATH` . the `/opt/pics`  is the `EXHAUST_PATH` insider container, it can’t modify beause of  the `EXHAUST_PATH` is define in config.json when building docker images.

