### PR TITLE
Add prefetch elapsed time

### DIFF
--- a/prefetch.go
+++ b/prefetch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 )
 
 func PrefetchImages(confImgPath string, ExhaustPath string, QUALITY string) {
+	var sTime = time.Now()
 	// maximum ongoing prefetch is depending on your core of CPU
 	log.Infof("Prefetching using %d cores", jobs)
 	var finishChan = make(chan int, jobs)
@@ -41,7 +43,8 @@ func PrefetchImages(confImgPath string, ExhaustPath string, QUALITY string) {
 	if err != nil {
 		log.Debug(err)
 	}
-
+	elapsed := time.Since(sTime)
 	_, _ = fmt.Fprintf(os.Stdout, "Prefetch completeY(^_^)Y\n\n")
+	_, _ = fmt.Fprintf(os.Stdout, "Convert %d file in %s (^_^)Y\n\n", count, elapsed)
 
 }


### PR DESCRIPTION
Hi guys,

I’ve add prefetch elapsed time when prefetch completed, and`os.Stdout`print as this:
```log
Prefetch completeY(^_^)Yconvert in progress: 766/768

Convert 766 file in 1m20.3148037s (^_^)Y
```