### PR TITLE
Add another UA for original image

### DIFF
--- a/router.go
+++ b/router.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gofiber/fiber"
 )
@@ -18,10 +19,9 @@ func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY 
 		var RawImageAbs = path.Join(ImgPath, reqURI) // /home/xxx/mypic/123.jpg
 		var ImgFilename = path.Base(reqURI)          // pure filename, 123.jpg
 		var finalFile string                         // We'll only need one c.sendFile()
-		// Check for Safari users. If they're Safari, just simply ignore everything.
+		// Check for Safari users. If they're Safari or the UA contains `AppleWebKit`(Might be the WeChat Browser), just simply ignore everything.
 		UA := c.Get("User-Agent")
-		if strings.Contains(UA, "Safari") && !strings.Contains(UA, "Chrome") &&
-			!strings.Contains(UA, "Firefox") {
+		if (strings.Contains(UA, "Safari") && !strings.Contains(UA, "Chrome") && !strings.Contains(UA, "Firefox")) || (strings.Contains(UA, "AppleWebKit")) {
 			log.Info("A Safari user has arrived...")
 			c.SendFile(RawImageAbs)
 			return


### PR DESCRIPTION
This is linked to https://github.com/webp-sh/webp_server_go/issues/39.

As the WeChat's builtin browser has an unique UA, which might be 

* `Mozilla/5.0 (iPad; CPU OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/80.0.3987.95 Mobile/15E148 Safari/604.1`
*  `Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/7.0.12(0x17000c2d) NetType/WIFI Language/zh_CN`

This PR checks whether the UA contains `AppleWebKit`, if this string is detected, original image will be used.