### PR TITLE
Feature: Add ETag header on output

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-  
-	log "github.com/sirupsen/logrus"
+
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func ChanErr(ccc chan int) {
@@ -71,6 +72,7 @@ func GenEtag(ImgAbsPath string) string {
 	}
 	crc := crc32.ChecksumIEEE(data)
 	return fmt.Sprintf(`W/"%d-%08X"`, len(data), crc)
+}
 
 func isSafari(UA string) bool {
 	// for more information, please check test case

--- a/helper.go
+++ b/helper.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
+	"hash/crc32"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func ChanErr(ccc chan int) {
@@ -58,4 +61,13 @@ func GenWebpAbs(RawImagePath string, ExhaustPath string, ImgFilename string, req
 	// Custom Exhaust: /path/to/exhaust/web_path/web_to/tsuki.jpg.1582558990.webp
 	WebpAbsolutePath := path.Clean(path.Join(ExhaustPath, path.Dir(reqURI), WebpFilename))
 	return cwd, WebpAbsolutePath
+}
+
+func GenEtag(ImgAbsPath string) string {
+	data, err := ioutil.ReadFile(ImgAbsPath)
+	if err != nil {
+		log.Info(err)
+	}
+	crc := crc32.ChecksumIEEE(data)
+	return fmt.Sprintf(`W/"%d-%08X"`, len(data), crc)
 }

--- a/helper.go
+++ b/helper.go
@@ -86,5 +86,4 @@ func isSafari(UA string) bool {
 		return true
 	}
 	return false
-
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -58,6 +58,16 @@ func TestGenWebpAbs(t *testing.T) {
 	}
 }
 
+func TestGenEtag(t *testing.T) {
+	var data = "./pics/png.jpg"
+	var expected = "W/\"1020764-262C0329\""
+	var result = GenEtag(data)
+
+	if result != expected {
+		t.Errorf("Result: [%s], Expected: [%s]", result, expected)
+	}
+}
+
 func TestisSafari(t *testing.T) {
 	// reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox
 	// https://developer.chrome.com/multidevice/user-agent#chrome_for_ios_user_agent

--- a/router.go
+++ b/router.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gofiber/fiber"
 )
@@ -23,6 +24,8 @@ func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY 
 		if strings.Contains(UA, "Safari") && !strings.Contains(UA, "Chrome") &&
 			!strings.Contains(UA, "Firefox") {
 			log.Info("A Safari user has arrived...")
+			etag := GenEtag(RawImageAbs)
+			c.Set("ETag", etag)
 			c.SendFile(RawImageAbs)
 			return
 		}
@@ -46,6 +49,8 @@ func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY 
 			log.Warn(msg)
 			c.Send(msg)
 			if ImageExists(RawImageAbs) {
+				etag := GenEtag(RawImageAbs)
+				c.Set("ETag", etag)
 				c.SendFile(RawImageAbs)
 			}
 			return
@@ -95,6 +100,8 @@ func Convert(ImgPath string, ExhaustPath string, AllowedTypes []string, QUALITY 
 			}
 			finalFile = WebpAbsPath
 		}
+		etag := GenEtag(finalFile)
+		c.Set("ETag", etag)
 		c.SendFile(finalFile)
 	}
 }

--- a/webp-server.go
+++ b/webp-server.go
@@ -141,7 +141,7 @@ func main() {
 	// Server Info
 	log.Infof("WebP Server %s %s", version, ListenAddress)
 
-	app.Get("/*", Convert(confImgPath, ExhaustPath, AllowedTypes, QUALITY))
+	app.All("/*", Convert(confImgPath, ExhaustPath, AllowedTypes, QUALITY))
 	app.Listen(ListenAddress)
 
 }


### PR DESCRIPTION
This branch will add E-Tag header on images rendered with WebP Server Go.

E-Tag is calculated with the file's file-size and it's crc32 checksum, an example output will look like this: `ETag: W/"524016-39D658B9"`.

This might be useful while working with proxy or CDN in front of it.