### PR TITLE
Update iOS render policy

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -9,8 +9,9 @@ import (
 	"path"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func ChanErr(ccc chan int) {
@@ -81,6 +82,7 @@ func goOrigin(UA string) bool {
 		// on Android and Linux
 	} else if strings.Contains(UA, "FxiOS") || strings.Contains(UA, "CriOS") {
 		//firefox and Chrome on iOS
+		return true
 	} else {
 		return true
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -3,8 +3,9 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
-import "github.com/stretchr/testify/assert"
 
 // test this file: go test -v -cover helper_test.go helper.go
 // test one function: go test -run TestGetFileContentType helper_test.go helper.go -v
@@ -70,14 +71,14 @@ func TestGoOrigin(t *testing.T) {
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36":                            false,
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36":                      false,
 		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36":                                      false,
-		"Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/83.0.4103.63 Mobile/15E148 Safari/604.1": false,
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/83.0.4103.63 Mobile/15E148 Safari/604.1": true,
 		"Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.60 Mobile Safari/537.36":                               false,
 
 		// Firefox on Windows, macOS, linux, iOS and Android
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0":                                                     false,
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:76.0) Gecko/20100101 Firefox/76.0":                                                 false,
 		"Mozilla/5.0 (X11; Linux i686; rv:76.0) Gecko/20100101 Firefox/76.0":                                                                 false,
-		"Mozilla/5.0 (iPad; CPU OS 10_15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/25.0 Mobile/15E148 Safari/605.1.15": false,
+		"Mozilla/5.0 (iPad; CPU OS 10_15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/25.0 Mobile/15E148 Safari/605.1.15": true,
 		"Mozilla/5.0 (Android 10; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0":                                                                  false,
 
 		// Safari on macOS and iOS

--- a/webp-server.go
+++ b/webp-server.go
@@ -21,7 +21,7 @@ type Config struct {
 	ExhaustPath  string   `json:"EXHAUST_PATH"`
 }
 
-const version = "0.1.4"
+const version = "0.1.5"
 
 var configPath string
 var prefetch bool


### PR DESCRIPTION
In accordance with Apple's requirements for browsers released through their App Store, iOS version of Chrome uses the iOS WebKit – which is Apple's own mobile rendering engine and components, developed for their Safari browser – therefore it is restricted from using Google's own V8 JavaScript engine.

This PR will make WebP Server Go render original image for Chrome/Firefox on iOS.