### PR TITLE
Update Golang to 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go: 
- - 1.13
+ - 1.14.7
 
 env: GO111MODULE=on
 arch:


### PR DESCRIPTION
Related: https://nvd.nist.gov/vuln/detail/CVE-2020-16845