### PR TITLE
Feature: Add Compression rate on header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ exhaust/
 /.idea/modules.xml
 /.idea/vcs.xml
 /.idea/webp_server_go.iml
+remote-raw/
+coverage.txt

--- a/config.go
+++ b/config.go
@@ -1,0 +1,59 @@
+// webp_server_go - config
+// 2020-11-27 13:05
+// Benny <benny.think@gmail.com>
+
+package main
+
+type Config struct {
+	Host         string   `json:"HOST"`
+	Port         string   `json:"PORT"`
+	ImgPath      string   `json:"IMG_PATH"`
+	Quality      string   `json:"QUALITY"`
+	AllowedTypes []string `json:"ALLOWED_TYPES"`
+	ExhaustPath  string   `json:"EXHAUST_PATH"`
+}
+
+var (
+	configPath               string
+	jobs                     int
+	dumpConfig, dumpSystemd  bool
+	verboseMode, showVersion bool
+	prefetch, proxyMode      bool
+
+	config  Config
+	version = "0.2.2"
+)
+
+const (
+	NotCompressed = "not_compressed"
+	WebpBigger    = "webp_bigger"
+)
+
+const (
+	sampleConfig = `
+{
+  "HOST": "127.0.0.1",
+  "PORT": "3333",
+  "QUALITY": "80",
+  "IMG_PATH": "./pics",
+  "EXHAUST_PATH": "./exhaust",
+  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp"]
+}`
+
+	sampleSystemd = `
+[Unit]
+Description=WebP Server Go
+Documentation=https://github.com/webp-sh/webp_server_go
+After=nginx.target
+
+[Service]
+Type=simple
+StandardError=journal
+WorkingDirectory=/opt/webps
+ExecStart=/opt/webps/webp-server --config /opt/webps/config.json
+Restart=always
+RestartSec=3s
+
+[Install]
+WantedBy=multi-user.target`
+)

--- a/helper.go
+++ b/helper.go
@@ -108,7 +108,7 @@ func genWebpAbs(RawImagePath string, ExhaustPath string, ImgFilename string, req
 		return "", ""
 	}
 	ModifiedTime := STAT.ModTime().Unix()
-	// webpFilename: abc.jpg.png -> abc.jpg.png1582558990.webp
+	// webpFilename: abc.jpg.png -> abc.jpg.png.1582558990.webp
 	WebpFilename := fmt.Sprintf("%s.%d.webp", ImgFilename, ModifiedTime)
 	cwd, _ := os.Getwd()
 
@@ -125,6 +125,22 @@ func genEtag(ImgAbsPath string) string {
 	}
 	crc := crc32.ChecksumIEEE(data)
 	return fmt.Sprintf(`W/"%d-%08X"`, len(data), crc)
+}
+
+func getCompressionRate(RawImagePath string, webpAbsPath string) string {
+	originFileInfo, err := os.Stat(RawImagePath)
+	if err != nil {
+		log.Info(err)
+	}
+	webpFileInfo, err := os.Stat(webpAbsPath)
+	if err != nil {
+		log.Info(err)
+	}
+	fmt.Println(originFileInfo.Size())
+	fmt.Println(webpFileInfo.Size())
+	compressionRate := float64(webpFileInfo.Size()) / float64(originFileInfo.Size())
+
+	return fmt.Sprintf(`%.2f`, compressionRate)
 }
 
 func goOrigin(UA string) bool {

--- a/helper.go
+++ b/helper.go
@@ -139,7 +139,7 @@ func getCompressionRate(RawImagePath string, webpAbsPath string) string {
 		return ""
 	}
 	compressionRate := float64(webpFileInfo.Size()) / float64(originFileInfo.Size())
-	log.Infof("The compress rate is %d/%d=%.2f", originFileInfo.Size(), webpFileInfo.Size(), compressionRate)
+	log.Debugf("The compress rate is %d/%d=%.2f", originFileInfo.Size(), webpFileInfo.Size(), compressionRate)
 	return fmt.Sprintf(`%.2f`, compressionRate)
 }
 

--- a/helper.go
+++ b/helper.go
@@ -91,7 +91,7 @@ func cleanProxyCache(cacheImagePath string) {
 	// Delete /node.png*
 	files, err := filepath.Glob(cacheImagePath + "*")
 	if err != nil {
-		fmt.Println(err)
+		log.Infoln(err)
 	}
 	for _, f := range files {
 		if err := os.Remove(f); err != nil {
@@ -130,16 +130,16 @@ func genEtag(ImgAbsPath string) string {
 func getCompressionRate(RawImagePath string, webpAbsPath string) string {
 	originFileInfo, err := os.Stat(RawImagePath)
 	if err != nil {
-		log.Info(err)
+		log.Warnf("fail to get raw image %v", err)
+		return ""
 	}
 	webpFileInfo, err := os.Stat(webpAbsPath)
 	if err != nil {
-		log.Info(err)
+		log.Warnf("fail to get webp image %v", err)
+		return ""
 	}
-	fmt.Println(originFileInfo.Size())
-	fmt.Println(webpFileInfo.Size())
 	compressionRate := float64(webpFileInfo.Size()) / float64(originFileInfo.Size())
-
+	log.Infof("The compress rate is %d/%d=%.2f", originFileInfo.Size(), webpFileInfo.Size(), compressionRate)
 	return fmt.Sprintf(`%.2f`, compressionRate)
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -157,3 +157,18 @@ func TestCleanProxyCache(t *testing.T) {
 	// test bad dir
 	cleanProxyCache("/aasdyg/dhj2/dagh")
 }
+
+func TestGetCompressionRate(t *testing.T) {
+	pic1 := "pics/webp_server.bmp"
+	pic2 := "pics/webp_server.jpg"
+	var ratio string
+
+	ratio = getCompressionRate(pic1, pic2)
+	assert.Equal(t, "0.16", ratio)
+
+	ratio = getCompressionRate(pic1, "pic2")
+	assert.Equal(t, "", ratio)
+
+	ratio = getCompressionRate("pic1", pic2)
+	assert.Equal(t, "", ratio)
+}

--- a/router.go
+++ b/router.go
@@ -20,8 +20,8 @@ func convert(c *fiber.Ctx) error {
 	var imgFilename = path.Base(reqURI)                 // pure filename, 123.jpg
 	var finalFile string                                // We'll only need one c.sendFile()
 	var UA = c.Get("User-Agent")
-	done := goOrigin(UA)
-	if done {
+	needOrigin := goOrigin(UA)
+	if needOrigin {
 		log.Infof("A Safari/IE/whatever user has arrived...%s", UA)
 		// Check for Safari users. If they're Safari, just simply ignore everything.
 
@@ -137,6 +137,8 @@ func convert(c *fiber.Ctx) error {
 		}
 		etag := genEtag(finalFile)
 		c.Set("ETag", etag)
+		compressionRate := getCompressionRate(rawImageAbs, webpAbsPath)
+		c.Set("X-Compression-Rate", compressionRate)
 		return c.SendFile(finalFile)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -20,16 +20,17 @@ func convert(c *fiber.Ctx) error {
 	var imgFilename = path.Base(reqURI)                 // pure filename, 123.jpg
 	var finalFile string                                // We'll only need one c.sendFile()
 	var UA = c.Get("User-Agent")
+	log.Debugf("Incoming connection from %s@%s with %s", UA, c.IP(), imgFilename)
+
 	needOrigin := goOrigin(UA)
 	if needOrigin {
 		log.Infof("A Safari/IE/whatever user has arrived...%s", UA)
 		// Check for Safari users. If they're Safari, just simply ignore everything.
-
 		etag := genEtag(rawImageAbs)
 		c.Set("ETag", etag)
+		c.Set("X-Compression-Rate", NotCompressed)
 		return c.SendFile(rawImageAbs)
 	}
-	log.Debugf("Incoming connection from %s@%s with %s", UA, c.IP(), imgFilename)
 
 	// check ext
 	var allowed = false
@@ -43,6 +44,7 @@ func convert(c *fiber.Ctx) error {
 			allowed = false
 		}
 	}
+
 	if !allowed {
 		msg := "File extension not allowed! " + imgFilename
 		log.Warn(msg)
@@ -60,7 +62,7 @@ func convert(c *fiber.Ctx) error {
 		// https://test.webp.sh/node.png
 		realRemoteAddr := config.ImgPath + reqURI
 		// Ping Remote for status code and etag info
-		fmt.Println("Remote Addr is " + realRemoteAddr + ", fetching..")
+		log.Infof("Remote Addr is %s fetching", realRemoteAddr)
 		statusCode, etagValue := getRemoteImageInfo(realRemoteAddr)
 		if statusCode == 200 {
 			// Check local path: /node.png-etag-<etagValue>
@@ -77,7 +79,7 @@ func convert(c *fiber.Ctx) error {
 				_ = os.MkdirAll(path.Dir(localEtagImagePath), 0755)
 				err := webpEncoder(localRemoteTmpPath, localEtagImagePath, float32(q), true, nil)
 				if err != nil {
-					fmt.Println(err)
+					log.Warning(err)
 				}
 				return c.SendFile(localEtagImagePath)
 			}
@@ -130,15 +132,14 @@ func convert(c *fiber.Ctx) error {
 			if err != nil {
 				log.Error(err)
 				_ = c.SendStatus(400)
-				_ = c.Send([]byte("Bad file!"))
+				_ = c.Send([]byte("Bad file. " + err.Error()))
 				return err
 			}
 			finalFile = webpAbsPath
 		}
 		etag := genEtag(finalFile)
 		c.Set("ETag", etag)
-		compressionRate := getCompressionRate(rawImageAbs, webpAbsPath)
-		c.Set("X-Compression-Rate", compressionRate)
+		c.Set("X-Compression-Rate", getCompressionRate(rawImageAbs, webpAbsPath))
 		return c.SendFile(finalFile)
 	}
 }

--- a/webp-server.go
+++ b/webp-server.go
@@ -12,54 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type Config struct {
-	Host         string   `json:"HOST"`
-	Port         string   `json:"PORT"`
-	ImgPath      string   `json:"IMG_PATH"`
-	Quality      string   `json:"QUALITY"`
-	AllowedTypes []string `json:"ALLOWED_TYPES"`
-	ExhaustPath  string   `json:"EXHAUST_PATH"`
-}
-
-var (
-	configPath                                                  string
-	jobs                                                        int
-	dumpConfig, dumpSystemd, verboseMode, prefetch, showVersion bool
-
-	proxyMode bool
-	config    Config
-	version   = "0.2.2"
-)
-
-const (
-	sampleConfig = `
-{
-  "HOST": "127.0.0.1",
-  "PORT": "3333",
-  "QUALITY": "80",
-  "IMG_PATH": "./pics",
-  "EXHAUST_PATH": "./exhaust",
-  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp"]
-}`
-
-	sampleSystemd = `
-[Unit]
-Description=WebP Server Go
-Documentation=https://github.com/webp-sh/webp_server_go
-After=nginx.target
-
-[Service]
-Type=simple
-StandardError=journal
-WorkingDirectory=/opt/webps
-ExecStart=/opt/webps/webp-server --config /opt/webps/config.json
-Restart=always
-RestartSec=3s
-
-[Install]
-WantedBy=multi-user.target`
-)
-
 func loadConfig(path string) Config {
 	jsonObject, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
This branch will add `X-Compression-Rate` header on images rendered with WebP Server Go.

The compression rate is calculated by dividing Original image size and rendered image size, expressed as a decimal, e.g: `0.03` for 3%.

WIP, test for this is needed.