### PR TITLE
fix unsupported browser + proxyMode bug, return 400 for not allow images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all:
 	./scripts/build.sh $(OS) $(ARCH)
 
 test:
-	go test -coverprofile=coverage.txt -covermode=atomic
+	go test -v -coverprofile=coverage.txt -covermode=atomic
 
 clean:
 	rm -rf builds

--- a/config.go
+++ b/config.go
@@ -19,9 +19,9 @@ var (
 	dumpConfig, dumpSystemd  bool
 	verboseMode, showVersion bool
 	prefetch, proxyMode      bool
-
-	config  Config
-	version = "0.3.1"
+	remoteRaw                = "remote-raw"
+	config                   Config
+	version                  = "0.3.1"
 )
 
 const (

--- a/helper.go
+++ b/helper.go
@@ -119,9 +119,12 @@ func genWebpAbs(RawImagePath string, ExhaustPath string, ImgFilename string, req
 }
 
 func genEtag(ImgAbsPath string) string {
+	if proxyMode {
+		ImgAbsPath = path.Join(remoteRaw, strings.Replace(ImgAbsPath, config.ImgPath, "", -1))
+	}
 	data, err := ioutil.ReadFile(ImgAbsPath)
 	if err != nil {
-		log.Info(err)
+		log.Warn(err)
 	}
 	crc := crc32.ChecksumIEEE(data)
 	return fmt.Sprintf(`W/"%d-%08X"`, len(data), crc)

--- a/helper_test.go
+++ b/helper_test.go
@@ -61,6 +61,14 @@ func TestGenEtag(t *testing.T) {
 
 	assert.Equalf(t, result, expected, "Result: [%s], Expected: [%s]", result, expected)
 
+	// proxy mode
+	proxyMode = true
+	config.ImgPath = "https://github.com/webp-sh/webp_server_go/raw/master/"
+	remoteRaw = ""
+	data = "https://github.com/webp-sh/webp_server_go/raw/master/pics/webp_server.png"
+	result = genEtag(data)
+	assert.Equal(t, result, "W/\"269387-6FFD6D2D\"")
+
 }
 
 func TestGoOrigin(t *testing.T) {


### PR DESCRIPTION
# fix unsupported browser + proxyMode bug
unsupported browser will go for origin, while in proxyMode we don't have cache images.

# return 400 for not allow files instead of 500
![image](https://user-images.githubusercontent.com/14024832/101242891-6c061900-3737-11eb-9565-cf14bdd4a1ee.png)

 resolve #61