### PR TITLE
Change docker image name to webpsh/webp-server-go

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -39,7 +39,7 @@ jobs:
           context: .
           platforms: linux/arm,linux/amd64,linux/arm64
           push: true
-          tags: webpsh/webps
+          tags: webpsh/webp-server-go
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
This PR will change our docker image from `webpsh/webps` to `webpsh/webp_server_go`.