### PR TITLE
Clean Path on routing to mitigate directory traversal

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ var (
 	prefetch, proxyMode      bool
 	remoteRaw                = "remote-raw"
 	config                   Config
-	version                  = "0.4.0"
+	version                  = "0.4.1"
 	releaseUrl               = "https://github.com/webp-sh/webp_server_go/releases/latest/download/"
 )
 

--- a/router.go
+++ b/router.go
@@ -16,6 +16,10 @@ import (
 func convert(c *fiber.Ctx) error {
 	//basic vars
 	var reqURI, _ = url.QueryUnescape(c.Path()) // /mypic/123.jpg
+
+	// delete ../ in reqURI to mitigate directory traversal
+	reqURI = path.Clean(reqURI)
+
 	var rawImageAbs string
 	if proxyMode {
 		rawImageAbs = config.ImgPath + reqURI


### PR DESCRIPTION
This PR will add `path.Clean` on `router.go` to mitigate directory traversal, also bumps version to 0.4.1.

Aims to solve: https://github.com/webp-sh/webp_server_go/issues/92