### PR TITLE
Optimize release procedure

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,6 +1,10 @@
-name: CI
+name: CI check on every push
 on:
   push:
+    paths-ignore:
+    - '**.md'
+    - 'Makefile'
+    - 'config.json'
 
 jobs:
   ci:

--- a/.github/workflows/release_binary.yaml
+++ b/.github/workflows/release_binary.yaml
@@ -2,6 +2,10 @@ name: Release Binaries
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'Makefile'
+      - 'config.json'
     tags:
       - '*'
 

--- a/.github/workflows/release_binary.yaml
+++ b/.github/workflows/release_binary.yaml
@@ -1,9 +1,9 @@
+name: Release Binaries
+
 on:
   push:
     tags:
       - '*'
-
-name: Release Binaries
 
 jobs:
   build:

--- a/.github/workflows/release_docker_image.yaml
+++ b/.github/workflows/release_docker_image.yaml
@@ -1,8 +1,10 @@
-name: build docker image
+name: Build and release docker images
 on:
   push:
     branches:
       - 'master'
+    tags:
+      - '*'
 
 jobs:
   docker:
@@ -12,6 +14,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Get the tag name
+        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -46,7 +51,8 @@ jobs:
         with:
           string: ${{ github.event.repository.full_name }}
 
-      - name: Build and push
+      - name: Build and push latest images
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -57,6 +63,22 @@ jobs:
             webpsh/webp-server-go
             webpsh/webps
             ghcr.io/${{ steps.ghcr_string.outputs.lowercase }}
+
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Build and push tagged images
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm,linux/amd64,linux/arm64
+          push: true
+          tags: |
+            webpsh/webp_server_go:${{ env.TAG }}
+            webpsh/webp-server-go:${{ env.TAG }}
+            webpsh/webps:${{ env.TAG }}
+            ghcr.io/${{ steps.ghcr_string.outputs.lowercase }}:${{ env.TAG }}
 
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/.github/workflows/release_docker_image.yaml
+++ b/.github/workflows/release_docker_image.yaml
@@ -1,6 +1,10 @@
 name: Build and release docker images
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'Makefile'
+      - 'config.json'
     branches:
       - 'master'
     tags:


### PR DESCRIPTION
This PR will optimize release.
* If commit is pushed to master, then only `latest` docker images will be release
* If we've push a tag, then it should release `webpsh/webp-server-go:${tag}` to DockerHub(and ghcr.io)
* If no `.go` files changed on commit to master, then no workflow should be ran.