### PR TITLE
Add asterisk support on allowed type on config.json

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -66,6 +66,9 @@ func imageExists(filename string) bool {
 func checkAllowedType(imgFilename string) bool {
 	imgFilename = strings.ToLower(imgFilename)
 	for _, allowedType := range config.AllowedTypes {
+		if allowedType == "*" {
+			return true
+		}
 		allowedType = "." + strings.ToLower(allowedType)
 		if strings.HasSuffix(imgFilename, allowedType) {
 			return true


### PR DESCRIPTION
Usually, our `config.json` is written as follows:
```json
{
  "HOST": "127.0.0.1",
  "PORT": "3333",
  "QUALITY": "80",
  "IMG_PATH": "https://test.webp.sh",
  "EXHAUST_PATH": "",
  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","gif"]
}
```

This works good on most scenarios, however, when dealing with "Remote Backend" with URL does not contain filetype, for example: `https://avatars.githubusercontent.com/u/24852034?v=4`, this will fail with `File extension not allowed!`.

This PR tries to solve this problem, by allowing `*` in `ALLOWED_TYPES`, that your `config.json` can be written as follows:

```json
{
  "HOST": "127.0.0.1",
  "PORT": "3333",
  "QUALITY": "80",
  "IMG_PATH": "https://test.webp.sh",
  "EXHAUST_PATH": "",
  "ALLOWED_TYPES": ["*"]
}
```

Do not merge this PR unless related PR on https://github.com/webp-sh/docs is made.