### PR TITLE
Mitigate directory traversal

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ var (
 	prefetch, proxyMode      bool
 	remoteRaw                = "remote-raw"
 	config                   Config
-	version                  = "0.4.1"
+	version                  = "0.4.2"
 	releaseUrl               = "https://github.com/webp-sh/webp_server_go/releases/latest/download/"
 )
 


### PR DESCRIPTION
There has been several comments about this issue:
* https://github.com/webp-sh/webp_server_go/pull/93#issuecomment-1046434809
* https://github.com/webp-sh/webp_server_go/issues/92

In the first link, we can found that if using cURL, the original image(file) will be returned, will will introduce the directory traversal issue, however when visiting using Web browser, the `File extension not allowed!` will be returned.

This PR tries to solve this problem by checking all the file extension regardless of the User-Agent.