### PR TITLE
use <details> to wrap stdout

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,7 +100,13 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            ```
+            <details><summary><b>error message</b> <i>[click to show]</i></summary>
+            <div>
+
+            ```log
             ${{ steps.trivy.outputs.stdout }}
             ```
+
+            </div>
+            </details>
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sometimes log message may be too long in comment.