### PR TITLE
Better RAM usage

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -144,6 +144,7 @@ func avifEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 		log.Error(err)
 		return err
 	}
+	img.Close()
 
 	convertLog("AVIF", p1, p2, quality)
 	return nil
@@ -191,6 +192,7 @@ func webpEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 		log.Error(err)
 		return err
 	}
+	img.Close()
 
 	convertLog("WebP", p1, p2, quality)
 	return nil

--- a/webp-server.go
+++ b/webp-server.go
@@ -100,6 +100,8 @@ Develop by WebP Server team. https://github.com/webp-sh`, version)
 
 	vips.Startup(&vips.Config{
 		ConcurrencyLevel: runtime.NumCPU(),
+		MaxCacheMem:      50 * 1024 * 1024,
+		MaxCacheSize:     1,
 	})
 	defer vips.Shutdown()
 


### PR DESCRIPTION
Tries to solve: https://github.com/webp-sh/webp_server_go/issues/198

## Tests

Tests are made by 20 lines of cURL commands like below:

```
curl -H "User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0" localhost:3333/1.jpg 
...
curl -H "User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0" localhost:3333/21.jpg
```

Each jpg image is about 10MiB in size, WebP Server Go starts at about 7MiB of RAM.

```
CONTAINER ID   NAME                  CPU %     MEM USAGE / LIMIT     MEM %     NET I/O          BLOCK I/O         PIDS
ba6960de985f   webp-server-webp-1    0.00%     7.473MiB / 45.89GiB   0.02%     5.65kB / 0B      0B / 0B           6
```

***

* Without `img.Close()` after test
```
a64c97a43426   webp-server-webp-1    0.05%     908.3MiB / 45.89GiB   1.93%     53.5kB / 14.1MB   0B / 15.5MB       19
```

* With `img.Close()` after test
```
c00b9b4240fb   webp-server-webp-1    0.04%     349MiB / 45.89GiB     0.74%     62.6kB / 15.7MB   0B / 16.4kB       19
```

* With `MaxCacheMem: 50 * 1024 * 1024,` and `MaxCacheSize: 1,` at startup, and with `img.Close()`
```
a79ff1b3b59f   webp-server-webp-1    0.03%     233.8MiB / 45.89GiB   0.50%     56.3kB / 12.2MB   0B / 28.6MB       20
```

However we need more information on `MaxCacheMem` and `MaxCacheSize` before considering merging this PR.

***
Ref:

```
func (*vips.ImageRef).Close()
Close manually closes the image and frees the memory. Calling Close() is optional. Images are automatically closed by GC. However, in high volume applications the GC can't keep up with the amount of memory, so you might want to manually close the images.
```
related issue: https://github.com/davidbyttow/govips/issues/358
