### PR TITLE
Allow convert on abnormal image

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	prefetch, proxyMode      bool
 	remoteRaw                = "remote-raw"
 	config                   Config
-	version                  = "0.8.1"
+	version                  = "0.8.2"
 )
 
 const (

--- a/encoder.go
+++ b/encoder.go
@@ -105,7 +105,12 @@ func convertImage(raw, optimized, itype string, extraParams ExtraParams) error {
 func avifEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 	// if convert fails, return error; success nil
 	var buf []byte
-	img, err := vips.NewImageFromFile(p1)
+	vips.NewImportParams().FailOnError.Set(true)
+	var boolFalse vips.BoolParameter
+	boolFalse.Set(false)
+	img, err := vips.LoadImageFromFile(p1, &vips.ImportParams{
+		FailOnError: boolFalse,
+	})
 	if err != nil {
 		return err
 	}
@@ -159,7 +164,12 @@ func avifEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 func webpEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 	// if convert fails, return error; success nil
 	var buf []byte
-	img, err := vips.NewImageFromFile(p1)
+	vips.NewImportParams().FailOnError.Set(true)
+	var boolFalse vips.BoolParameter
+	boolFalse.Set(false)
+	img, err := vips.LoadImageFromFile(p1, &vips.ImportParams{
+		FailOnError: boolFalse,
+	})
 	if err != nil {
 		return err
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -105,7 +105,6 @@ func convertImage(raw, optimized, itype string, extraParams ExtraParams) error {
 func avifEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 	// if convert fails, return error; success nil
 	var buf []byte
-	vips.NewImportParams().FailOnError.Set(true)
 	var boolFalse vips.BoolParameter
 	boolFalse.Set(false)
 	img, err := vips.LoadImageFromFile(p1, &vips.ImportParams{
@@ -164,7 +163,6 @@ func avifEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 func webpEncoder(p1, p2 string, quality int, extraParams ExtraParams) error {
 	// if convert fails, return error; success nil
 	var buf []byte
-	vips.NewImportParams().FailOnError.Set(true)
 	var boolFalse vips.BoolParameter
 	boolFalse.Set(false)
 	img, err := vips.LoadImageFromFile(p1, &vips.ImportParams{


### PR DESCRIPTION
Possible fix for https://github.com/webp-sh/webp_server_go/issues/211

But we might need more tests since FailOnError is set to true.

Similar issue: https://github.com/lovell/sharp/issues/2032