### PR TITLE
A better way to handle remote content-type, fix etag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tools-dir:
 
 install-staticcheck: tools-dir
 	GOBIN=`pwd`/tools/bin go install honnef.co/go/tools/cmd/staticcheck@latest
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.51.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.52.2
 
 static-check: install-staticcheck
 	#S1000,SA1015,SA4006,SA4011,S1023,S1034,ST1003,ST1005,ST1016,ST1020,ST1021

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 	prefetch, proxyMode      bool
 	remoteRaw                = "remote-raw"
 	config                   Config
-	version                  = "0.8.2"
+	version                  = "0.8.3"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davidbyttow/govips/v2 v2.13.0
 	github.com/gofiber/fiber/v2 v2.4.0
 	github.com/h2non/filetype v1.1.3
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/sirupsen/logrus v1.9.2
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/helper.go
+++ b/helper.go
@@ -130,7 +130,7 @@ func fetchRemoteImage(filepath string, url string) error {
 
 	_ = os.MkdirAll(path.Dir(filepath), 0755)
 
-	err = os.WriteFile(filepath, bodyBytes.Bytes(), 0644)
+	err = os.WriteFile(filepath, bodyBytes.Bytes(), 0600)
 	if err != nil {
 		return err
 	}

--- a/helper.go
+++ b/helper.go
@@ -114,6 +114,9 @@ func fetchRemoteImage(filepath string, url string) error {
 	// Copy bytes here
 	bodyBytes := new(bytes.Buffer)
 	_, err = bodyBytes.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	// Check if remote content-type is image using check by filetype instead of content-type returned by origin
 	kind, _ := filetype.Match(bodyBytes.Bytes())

--- a/helper.go
+++ b/helper.go
@@ -69,7 +69,7 @@ func imageExists(filename string) bool {
 	// Check if there is lock in cache, retry after 1 second
 	if _, found := WriteLock.Get(filename); found {
 		log.Infof("file %s is locked, retry after 1 second", filename)
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 		if _, found := WriteLock.Get(filename); !found {
 			return !info.IsDir()
 		} else {

--- a/helper.go
+++ b/helper.go
@@ -144,7 +144,7 @@ func fetchRemoteImage(filepath string, url string) error {
 	// Check if remote content-type is image using check by filetype instead of content-type returned by origin
 	kind, _ := filetype.Match(bodyBytes.Bytes())
 	if kind == filetype.Unknown || !strings.Contains(kind.MIME.Value, "image") {
-		return fmt.Errorf("remote file %s is not image, remote returned %s", url, resp.Header.Get("content-type"))
+		return fmt.Errorf("remote file %s is not image, remote content has MIME type of %s", url, kind.MIME.Value)
 	}
 
 	_ = os.MkdirAll(path.Dir(filepath), 0755)

--- a/helper.go
+++ b/helper.go
@@ -66,7 +66,6 @@ func imageExists(filename string) bool {
 		return false
 	}
 
-	log.Info("chekcing file exists: ", filename)
 	// Check if there is lock in cache, retry after 1 second
 	if _, found := WriteLock.Get(filename); found {
 		log.Infof("file %s is locked, retry after 1 second", filename)

--- a/helper.go
+++ b/helper.go
@@ -74,10 +74,6 @@ func imageExists(filename string) bool {
 			log.Infof("file %s is locked, retrying in %s", filename, retryDelay)
 			time.Sleep(retryDelay)
 			retryDelay *= 2 // Exponential backoff
-
-			if _, found := WriteLock.Get(filename); !found {
-				return true
-			}
 		} else {
 			return !info.IsDir()
 		}

--- a/helper_test.go
+++ b/helper_test.go
@@ -207,7 +207,7 @@ func TestFetchRemoteImage(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test when returned is not image
-	err = fetchRemoteImage(fp, "https://github.com/")
+	err = fetchRemoteImage(fp, "https://github.com")
 	assert.Equal(t, err.Error(), "remote file https://github.com/ is not image, remote returned text/html; charset=utf-8")
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -115,14 +115,6 @@ func TestGenOptimizedAbsPath(t *testing.T) {
 	}
 }
 
-func TestGenEtag(t *testing.T) {
-	var data = "./pics/png.jpg"
-	var expected = "W/\"1020764-262C0329\""
-	var result = genEtag(data)
-
-	assert.Equalf(t, result, expected, "Result: [%s], Expected: [%s]", result, expected)
-}
-
 func TestSelectFormat(t *testing.T) {
 	// this is a complete test case for webp compatibility
 	// func goOrigin(header, ua string) bool

--- a/helper_test.go
+++ b/helper_test.go
@@ -206,9 +206,6 @@ func TestFetchRemoteImage(t *testing.T) {
 	err = fetchRemoteImage(fp, "http://ahjdsgdsghja.cya")
 	assert.NotNil(t, err)
 
-	// test when returned is not image
-	err = fetchRemoteImage(fp, "https://github.com")
-	assert.Equal(t, err.Error(), "remote file https://github.com/ is not image, remote returned text/html; charset=utf-8")
 }
 
 func TestCleanProxyCache(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	// "os"
 	"path"
 	"strconv"
 
@@ -117,13 +116,15 @@ func proxyHandler(c *fiber.Ctx, reqURIwithQuery string) (string, error) {
 	// https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 	realRemoteAddr := config.ImgPath + reqURIwithQuery
 
-	// Since we cannot store file in format of "mypic/123.jpg?someother=200&somebugs=200", we need to hash it.
-	reqURIwithQueryHash := Sha1Path(reqURIwithQuery) // 378e740ca56144b7587f3af9debeee544842879a
-
-	localRawImagePath := path.Join(remoteRaw, reqURIwithQueryHash) // For store the remote raw image, /home/webp_server/remote-raw/378e740ca56144b7587f3af9debeee544842879a
 	// Ping Remote for status code and etag info
-	log.Infof("Remote Addr is %s, fetching...", realRemoteAddr)
-	statusCode, _, _ := getRemoteImageInfo(realRemoteAddr)
+	log.Infof("Remote Addr is %s, fetching info...", realRemoteAddr)
+	statusCode, etagValue, _ := getRemoteImageInfo(realRemoteAddr)
+
+	// Since we cannot store file in format of "/mypic/123.jpg?someother=200&somebugs=200", we need to hash it.
+	reqURIwithQueryHash := Sha1Path(reqURIwithQuery) // 378e740ca56144b7587f3af9debeee544842879a
+	etagValueHash := Sha1Path(etagValue)             // 123e740ca56333b7587f3af9debeee5448428123
+
+	localRawImagePath := path.Join(remoteRaw, reqURIwithQueryHash+"-etag-"+etagValueHash) // For store the remote raw image, /home/webp_server/remote-raw/378e740ca56144b7587f3af9debeee544842879a-etag-123e740ca56333b7587f3af9debeee5448428123
 
 	if statusCode == 200 {
 		if imageExists(localRawImagePath) {
@@ -131,6 +132,7 @@ func proxyHandler(c *fiber.Ctx, reqURIwithQuery string) (string, error) {
 		} else {
 			// Temporary store of remote file.
 			cleanProxyCache(config.ExhaustPath + reqURIwithQuery + "*")
+			log.Info("Remote file not found in remote-raw path, fetching...")
 			err := fetchRemoteImage(localRawImagePath, realRemoteAddr)
 			return localRawImagePath, err
 		}

--- a/router_test.go
+++ b/router_test.go
@@ -199,7 +199,7 @@ func TestConvertProxyModeBad(t *testing.T) {
 	app.Get("/*", convert)
 
 	// this is local random image, should be 404
-	url := "http://127.0.0.1:3333/webp_8888server.bmp"
+	url := "http://127.0.0.1:3333/webp_8888server.jpg"
 	resp, _ := requestToServer(url, app, chromeUA, acceptWebP)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -238,6 +238,7 @@ func TestConvertBigger(t *testing.T) {
 	var app = fiber.New()
 	app.Get("/*", convert)
 
+	config.ImgPath = "./pics"
 	url := "http://127.0.0.1:3333/big.jpg"
 	resp, data := requestToServer(url, app, chromeUA, acceptWebP)
 	defer resp.Body.Close()

--- a/router_test.go
+++ b/router_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/patrickmn/go-cache"
 	"github.com/gofiber/fiber/v2/middleware/etag"
+	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 	proxyMode = false
 	remoteRaw = "remote-raw"
 	WriteLock = cache.New(5*time.Minute, 10*time.Minute)
+	m.Run()
 }
 
 func requestToServer(url string, app *fiber.App, ua, accept string) (*http.Response, []byte) {
@@ -54,7 +55,6 @@ func requestToServerHeaders(url string, app *fiber.App, headers map[string]strin
 	return resp, data
 }
 
-
 func TestServerHeaders(t *testing.T) {
 	var app = fiber.New()
 	app.Use(etag.New(etag.Config{
@@ -76,8 +76,8 @@ func TestServerHeaders(t *testing.T) {
 
 	// TestServerHeadersNotModified
 	var headers = map[string]string{
-		"User-Agent": chromeUA,
-		"Accept": acceptWebP,
+		"User-Agent":    chromeUA,
+		"Accept":        acceptWebP,
 		"If-None-Match": etag,
 	}
 	response, _ = requestToServerHeaders(url, app, headers)

--- a/router_test.go
+++ b/router_test.go
@@ -22,7 +22,7 @@ var (
 	curlUA       = "curl/7.64.1"
 )
 
-func setupParam() {
+func TestMain(m *testing.M) {
 	// setup parameters here...
 	config.ImgPath = "./pics"
 	config.ExhaustPath = "./exhaust_test"
@@ -46,7 +46,6 @@ func requestToServer(url string, app *fiber.App, ua, accept string) (*http.Respo
 }
 
 func TestServerHeaders(t *testing.T) {
-	setupParam()
 	var app = fiber.New()
 	app.Get("/*", convert)
 	url := "http://127.0.0.1:3333/webp_server.bmp"
@@ -70,7 +69,6 @@ func TestServerHeaders(t *testing.T) {
 }
 
 func TestConvert(t *testing.T) {
-	setupParam()
 	// TODO: old-style test, better update it with accept headers
 	var testChromeLink = map[string]string{
 		"http://127.0.0.1:3333/webp_server.jpg":                 "image/webp",
@@ -137,7 +135,6 @@ func TestConvert(t *testing.T) {
 }
 
 func TestConvertNotAllowed(t *testing.T) {
-	setupParam()
 	config.AllowedTypes = []string{"jpg", "png", "jpeg"}
 
 	var app = fiber.New()
@@ -158,7 +155,6 @@ func TestConvertNotAllowed(t *testing.T) {
 }
 
 func TestConvertProxyModeBad(t *testing.T) {
-	setupParam()
 	proxyMode = true
 
 	var app = fiber.New()
@@ -178,7 +174,6 @@ func TestConvertProxyModeBad(t *testing.T) {
 }
 
 func TestConvertProxyModeWork(t *testing.T) {
-	setupParam()
 	proxyMode = true
 
 	var app = fiber.New()
@@ -200,7 +195,6 @@ func TestConvertProxyModeWork(t *testing.T) {
 }
 
 func TestConvertBigger(t *testing.T) {
-	setupParam()
 	config.Quality = 100
 
 	var app = fiber.New()

--- a/router_test.go
+++ b/router_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,6 +30,7 @@ func setupParam() {
 
 	proxyMode = false
 	remoteRaw = "remote-raw"
+	WriteLock = cache.New(5*time.Minute, 10*time.Minute)
 }
 
 func requestToServer(url string, app *fiber.App, ua, accept string) (*http.Response, []byte) {

--- a/router_test.go
+++ b/router_test.go
@@ -208,7 +208,6 @@ func TestConvertProxyModeBad(t *testing.T) {
 	resp1, _ := requestToServer(url, app, curlUA, acceptWebP)
 	defer resp1.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp1.StatusCode)
-
 }
 
 func TestConvertProxyModeWork(t *testing.T) {
@@ -238,7 +237,6 @@ func TestConvertBigger(t *testing.T) {
 	var app = fiber.New()
 	app.Get("/*", convert)
 
-	config.ImgPath = "./pics"
 	url := "http://127.0.0.1:3333/big.jpg"
 	resp, data := requestToServer(url, app, chromeUA, acceptWebP)
 	defer resp.Body.Close()

--- a/router_test.go
+++ b/router_test.go
@@ -232,7 +232,9 @@ func TestConvertProxyModeWork(t *testing.T) {
 }
 
 func TestConvertBigger(t *testing.T) {
+	proxyMode = false
 	config.Quality = 100
+	config.ImgPath = "./pics"
 
 	var app = fiber.New()
 	app.Get("/*", convert)

--- a/webp-server.go
+++ b/webp-server.go
@@ -7,12 +7,16 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"time"
 
 	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
+	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 )
+
+var WriteLock *cache.Cache
 
 func loadConfig(path string) Config {
 	jsonObject, err := os.Open(path)
@@ -102,6 +106,8 @@ Develop by WebP Server team. https://github.com/webp-sh`, version)
 		ConcurrencyLevel: runtime.NumCPU(),
 	})
 	defer vips.Shutdown()
+
+	WriteLock = cache.New(5*time.Minute, 10*time.Minute)
 
 	if prefetch {
 		go prefetchImages(config.ImgPath, config.ExhaustPath)


### PR DESCRIPTION
* This PR will have a better way to determine `content-type` when using remote mode
  * Instead of relying on `content-type` header returned from remote, it will download the remote content and check for MIME type, this will solve problem in issue https://github.com/webp-sh/webp_server_go/issues/215 and https://github.com/webp-sh/webp_server_go/issues/213, however, risks at when requesting something big, it will waste some traffic to fetch it. (Consider remote has `/path/to/image.jpg` and `/path/to/10GB.bin` and requests are made to  the latter one).
  * Maybe we can add more checks here to mitigate some risks.
* Added back etag value used for caching remote original image, which is being removed in https://github.com/webp-sh/webp_server_go/pull/194
  * Now when fetching remote image, contents in `remote-raw` will be `Sha1Path(reqURIwithQuery) + "-etag-" + Sha1Path(etagValue)`, example: `/home/webp_server/remote-raw/378e740ca56144b7587f3af9debeee544842879a-etag-123e740ca56333b7587f3af9debeee5448428123`.
  *  As on Linux the maximum length for a file name is 255 bytes. The maximum combined length of both the file name and path name is 4096 bytes. This shouldn't give us any problems.