### PR TITLE
Add libjemalloc2 and libtcmalloc-minimal4 to Dockerfile

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,68 @@
+name: Integration Tests
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+    - '**.md'
+    - 'Makefile'
+    - 'config.json'
+
+jobs:
+  glib_malloc:
+    name: Glib malloc RAM usage test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/webp-sh/webp_server_go
+
+      - name: Start the container
+        run: |
+          cp tests/glib_malloc/docker-compose.yml ./
+          docker-compose up -d
+    
+      - name: Send Requests to Server
+        run: |
+          cd pics
+          find * -type f -print | xargs -I {} curl -H "User-Agent: Mozilla/5.0 Gecko/20100101 Firefox/98.0" http://localhost:3333/{}
+
+      - name: Get container RAM stats
+        run: |
+          docker stats --no-stream
+
+  jemalloc:
+    name: jemalloc RAM usage test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/webp-sh/webp_server_go
+
+      - name: Start the container
+        run: |
+          cp tests/jemalloc/docker-compose.yml ./
+          docker-compose up -d
+    
+      - name: Send Requests to Server
+        run: |
+          cd pics
+          find * -type f -print | xargs -I {} curl -H "User-Agent: Mozilla/5.0 Gecko/20100101 Firefox/98.0" http://localhost:3333/{}
+
+      - name: Get container RAM stats
+        run: |
+          docker stats --no-stream

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /build && sed -i "s|.\/pics|${IMG_PATH}|g" config.json  \
 
 FROM debian:bullseye-slim
 
-RUN apt update && apt install --no-install-recommends libvips ca-certificates -y && rm -rf /var/lib/apt/lists/* &&  rm -rf /var/cache/apt/archives/*
+RUN apt update && apt install --no-install-recommends libvips ca-certificates libjemalloc2 libtcmalloc-minimal4 -y && rm -rf /var/lib/apt/lists/* &&  rm -rf /var/cache/apt/archives/*
 
 COPY --from=builder /build/webp-server  /usr/bin/webp-server
 COPY --from=builder /build/config.json /etc/config.json

--- a/tests/glib_malloc/docker-compose.yml
+++ b/tests/glib_malloc/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  webp:
+    image: webpsh/webp-server-go
+    restart: always
+    environment:
+      - MALLOC_ARENA_MAX=1
+    volumes:
+      - ./pics:/opt/pics
+      - ./exhaust:/opt/exhaust
+    ports:
+      -  127.0.0.1:3333:3333

--- a/tests/jemalloc/docker-compose.yml
+++ b/tests/jemalloc/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  webp:
+    image: webpsh/webp-server-go
+    restart: always
+    environment:
+      - MALLOC_ARENA_MAX=1
+      - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+    volumes:
+      - ./pics:/opt/pics
+      - ./exhaust:/opt/exhaust
+    ports:
+      -  127.0.0.1:3333:3333


### PR DESCRIPTION
This PR adds two malloc lib to Dockerfile, which allows user to switch between them:

* `LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2` will use jemalloc
* `LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4.5.6` will use tcmalloc
* If no LD_PRELOAD set, it will use Glibc malloc

```
version: '3'

services:
  webp:
    image: webpsh/webp-server-go
    restart: always
    environment:
      - MALLOC_ARENA_MAX=1
      #- LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
      - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4.5.6
    volumes:
      - ./pics:/opt/pics
      - ./exhaust:/opt/exhaust
      - ./config.json:/etc/config.json
    ports:
      -  127.0.0.1:3333:3333
```