### PR TITLE
iOS 16 supports AVIF and WebP

### DIFF
--- a/handler/router.go
+++ b/handler/router.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 	"net/url"
-	"strings"
+	"os"
 	"webp_server_go/config"
 	"webp_server_go/encoder"
 	"webp_server_go/helper"
@@ -93,11 +93,10 @@ func Convert(c *fiber.Ctx) error {
 	}
 
 	finalFilename := helper.FindSmallestFiles(availableFiles)
-	if strings.HasSuffix(finalFilename, ".webp ") {
-		c.Set("Content-Type", "image/webp")
-	} else if strings.HasSuffix(finalFilename, ".avif") {
-		c.Set("Content-Type", "image/avif")
-	}
+
+	buf, _ := os.ReadFile(finalFilename)
+	contentType := helper.GetFileContentType(buf)
+	c.Set("Content-Type", contentType)
 
 	c.Set("X-Compression-Rate", helper.GetCompressionRate(rawImageAbs, finalFilename))
 	return c.SendFile(finalFilename)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -2,14 +2,15 @@ package helper
 
 import (
 	"fmt"
-	"github.com/cespare/xxhash"
-	"github.com/valyala/fasthttp"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
 	"webp_server_go/config"
+
+	"github.com/cespare/xxhash"
+	"github.com/valyala/fasthttp"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -144,8 +145,14 @@ func GuessSupportedFormat(header *fasthttp.RequestHeader) []string {
 	// chrome on iOS will not send valid image accept header
 	if strings.Contains(ua, "iPhone OS 14") || strings.Contains(ua, "CPU OS 14") ||
 		strings.Contains(ua, "iPhone OS 15") || strings.Contains(ua, "CPU OS 15") ||
+		strings.Contains(ua, "iPhone OS 16") || strings.Contains(ua, "CPU OS 16") ||
 		strings.Contains(ua, "Android") || strings.Contains(ua, "Linux") {
 		supported["webp"] = true
+	}
+
+	// iOS 16 supports AVIF
+	if strings.Contains(ua, "iPhone OS 16") || strings.Contains(ua, "CPU OS 16") {
+		supported["avif"] = true
 	}
 
 	// save true value's key to slice

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -146,12 +146,14 @@ func GuessSupportedFormat(header *fasthttp.RequestHeader) []string {
 	if strings.Contains(ua, "iPhone OS 14") || strings.Contains(ua, "CPU OS 14") ||
 		strings.Contains(ua, "iPhone OS 15") || strings.Contains(ua, "CPU OS 15") ||
 		strings.Contains(ua, "iPhone OS 16") || strings.Contains(ua, "CPU OS 16") ||
+		strings.Contains(ua, "iPhone OS 17") || strings.Contains(ua, "CPU OS 17") ||
 		strings.Contains(ua, "Android") || strings.Contains(ua, "Linux") {
 		supported["webp"] = true
 	}
 
 	// iOS 16 supports AVIF
-	if strings.Contains(ua, "iPhone OS 16") || strings.Contains(ua, "CPU OS 16") {
+	if strings.Contains(ua, "iPhone OS 16") || strings.Contains(ua, "CPU OS 16") ||
+		strings.Contains(ua, "iPhone OS 17") || strings.Contains(ua, "CPU OS 17") {
 		supported["avif"] = true
 	}
 


### PR DESCRIPTION
From https://caniuse.com/avif we know that starting from iOS 16, it supports AVIF, but browser on iOS will not send the correct `Accept` header, on a testing machine (iPhone 11 + iOS 16.6 + Chrome), requests headers are:
* UA: `Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.124 Mobile/15E148 Safari/604.1`
* Accept: `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`

While on Chrome on Linux, UA and accept are:
* UA: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36`
* Accept: `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7`

In cases above, if we found `iPhone OS 16` in UA, we should be able to render WebP/AVIF to them, without checking their `Accept` header.