### PR TITLE
fix code cov

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,7 +34,7 @@ jobs:
           sudo apt install libvips-dev -y
 
       - name: run test cases
-        run: make test && make
+        run: make && make test
 
       - name: Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
worth mentioning:

1. this commit remove on push https://github.com/webp-sh/webp_server_go/commit/d104c1fbca09f652675ef56c1f2011aebd6c5629
2. this commit `make clean` will delete more files, including `codecov.txt` https://github.com/webp-sh/webp_server_go/commit/23bbed8ce6e15e39e8f124a0f671a90b96798a79
3. although on push was added back here https://github.com/webp-sh/webp_server_go/commit/13281d929b275de58c5a92322cc87f394f42344d , we would first run `make test` and then `make`

So `codecov.txt` is missing! So we're missing code coverage data for more than a year!