### PR TITLE
Default ReductionEffort to 0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ var (
 	ProxyMode   bool
 	Prefetch    bool
 	Config      jsonFile
-	Version     = "0.9.4"
+	Version     = "0.9.5"
 	WriteLock   = cache.New(5*time.Minute, 10*time.Minute)
 )
 

--- a/webp-server.go
+++ b/webp-server.go
@@ -17,8 +17,8 @@ import (
 )
 
 var app = fiber.New(fiber.Config{
-	ServerHeader:          "Webp Server Go",
-	AppName:               "Webp Server Go",
+	ServerHeader:          "WebP Server Go",
+	AppName:               "WebP Server Go",
 	DisableStartupMessage: true,
 	ProxyHeader:           "X-Real-IP",
 })
@@ -43,7 +43,7 @@ func setupLogger() {
 		TimeFormat: config.TimeDateFormat,
 	}))
 	app.Use(recover.New(recover.Config{}))
-	log.Infoln("fiber ready.")
+	log.Infoln("WebP Server Go ready.")
 }
 
 func init() {


### PR DESCRIPTION
ReductionEffort from libvips docs:
> Use effort to control how much CPU time to spend attempting to reduce file size. A higher value means more effort and therefore CPU time should be spent. It has the range 0-6 and a default value of 4.

From the issue https://github.com/webp-sh/webp_server_go/issues/253#issuecomment-1639683004 we can see after 0.9.1 the ReductionEffort is set to 4 to mitigate problems stated in https://github.com/webp-sh/webp_server_go/issues/234.

However, using ReductionEffort to 4 for all images will cause performance degrade to about 3 times slower than before, and is using more RAM, benchmark as below:

0.9.4 with jemalloc
![image](https://github.com/webp-sh/webp_server_go/assets/24852034/2a3c8c8b-2546-4568-ae66-eb3add8efcb8)

0.9.4 with jemalloc and ReductionEffort set to 0
![image](https://github.com/webp-sh/webp_server_go/assets/24852034/bbb3d8b3-aded-45f7-85e8-bb4d5e55a058)

In this PR
* The ReductionEffort is set to 0 by default for faster encoding speed, and will retry ReductionEffort 4 if encode error occurs.
* Some typo fix
* Bump version to 0.9.5