### PR TITLE
M1 should be arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ else
 endif
 
 ifeq ($(shell uname -m),aarch64)
-	ARCH=arm64
+    ARCH=arm64
+else ifeq ($(shell uname -m),arm64)
+    ARCH=arm64
 else
-	ARCH=amd64
+    ARCH=amd64
 endif
 
 default:


### PR DESCRIPTION
Under MacBook M1, `uname -m` returns `arm64`, we should pass `ARCH=arm64` when building.