### PR TITLE
ISSUE-268 Add min file size param to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","gif","svg","heic"],
   "IMG_MAP": {},
   "ENABLE_AVIF": false,
-  "ENABLE_EXTRA_PARAMS": false
+  "ENABLE_EXTRA_PARAMS": false,
+  "MIN_FILE_SIZE_BYTES": "0"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type jsonFile struct {
 	ExhaustPath       string            `json:"EXHAUST_PATH"`
 	EnableAVIF        bool              `json:"ENABLE_AVIF"`
 	EnableExtraParams bool              `json:"ENABLE_EXTRA_PARAMS"`
+	MinFileSizeBytes  int64             `json:"MIN_FILE_SIZE_BYTES,string"`
 }
 
 func init() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  webp:
+    build:
+      context: .
+    restart: always
+    environment:
+      - MALLOC_ARENA_MAX=1
+    volumes:
+      - ./p4:/opt/pics
+      - ./exhaust:/opt/exhaust
+      - ./metadata:/opt/metadata
+    ports:
+      -  127.0.0.1:3333:3333


### PR DESCRIPTION
# Description
- Adds support for this issue. https://github.com/webp-sh/webp_server_go/issues/268
  - `MIN_FILE_SIZE_BYTES` can be set in config file. Files smaller than this size will be skipped during compression. 
- Added support only for `webpEncoder` for now for initial feedback.