### PR TITLE
Parse flat before load config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ var (
 	ProxyMode      bool
 	Prefetch       bool
 	Config         jsonFile
-	Version        = "0.9.9"
+	Version        = "0.9.11"
 	WriteLock      = cache.New(5*time.Minute, 10*time.Minute)
 	RemoteRaw      = "./remote-raw"
 	Metadata       = "./metadata"

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -20,12 +20,12 @@ var (
 )
 
 func init() {
+	vips.LoggingSettings(nil, vips.LogLevelError)
 	vips.Startup(&vips.Config{
 		ConcurrencyLevel: runtime.NumCPU(),
 	})
 	boolFalse.Set(false)
 	intMinusOne.Set(-1)
-
 }
 
 func resizeImage(img *vips.ImageRef, extraParams config.ExtraParams) error {

--- a/webp-server.go
+++ b/webp-server.go
@@ -47,23 +47,17 @@ func setupLogger() {
 }
 
 func init() {
-	// main init is the last one to be called
-	flag.Parse()
-	config.LoadConfig()
-	setupLogger()
-}
-
-func main() {
 	// Our banner
 	banner := fmt.Sprintf(`
-▌ ▌   ▌  ▛▀▖ ▞▀▖                ▞▀▖
-▌▖▌▞▀▖▛▀▖▙▄▘ ▚▄ ▞▀▖▙▀▖▌ ▌▞▀▖▙▀▖ ▌▄▖▞▀▖
-▙▚▌▛▀ ▌ ▌▌   ▖ ▌▛▀ ▌  ▐▐ ▛▀ ▌   ▌ ▌▌ ▌
-▘ ▘▝▀▘▀▀ ▘   ▝▀ ▝▀▘▘   ▘ ▝▀▘▘   ▝▀ ▝▀
-
-WebP Server Go - v%s
-Develop by WebP Server team. https://github.com/webp-sh`, config.Version)
-
+		▌ ▌   ▌  ▛▀▖ ▞▀▖                ▞▀▖
+		▌▖▌▞▀▖▛▀▖▙▄▘ ▚▄ ▞▀▖▙▀▖▌ ▌▞▀▖▙▀▖ ▌▄▖▞▀▖
+		▙▚▌▛▀ ▌ ▌▌   ▖ ▌▛▀ ▌  ▐▐ ▛▀ ▌   ▌ ▌▌ ▌
+		▘ ▘▝▀▘▀▀ ▘   ▝▀ ▝▀▘▘   ▘ ▝▀▘▘   ▝▀ ▝▀
+		
+		WebP Server Go - v%s
+		Develop by WebP Server team. https://github.com/webp-sh`, config.Version)
+	// main init is the last one to be called
+	flag.Parse()
 	// process cli params
 	if config.DumpConfig {
 		fmt.Println(config.SampleConfig)
@@ -77,11 +71,15 @@ Develop by WebP Server team. https://github.com/webp-sh`, config.Version)
 		fmt.Printf("\n %c[1;32m%s%c[0m\n\n", 0x1B, banner+"", 0x1B)
 		os.Exit(0)
 	}
+	config.LoadConfig()
+	fmt.Printf("\n %c[1;32m%s%c[0m\n\n", 0x1B, banner, 0x1B)
+	setupLogger()
+}
 
+func main() {
 	if config.Prefetch {
 		go encoder.PrefetchImages()
 	}
-
 	app.Use(etag.New(etag.Config{
 		Weak: true,
 	}))
@@ -89,7 +87,6 @@ Develop by WebP Server team. https://github.com/webp-sh`, config.Version)
 	listenAddress := config.Config.Host + ":" + config.Config.Port
 	app.Get("/*", handler.Convert)
 
-	fmt.Printf("\n %c[1;32m%s%c[0m\n\n", 0x1B, banner, 0x1B)
 	fmt.Println("WebP Server Go is Running on http://" + listenAddress)
 
 	_ = app.Listen(listenAddress)


### PR DESCRIPTION
Fix for https://github.com/webp-sh/webp_server_go/issues/271,will parse and process flags before loading config file, affects both docker image and binary.

```
docker run --rm webpsh/webp-server-go webp-server -dump-config

{
  "HOST": "127.0.0.1",
  "PORT": "3333",
  "QUALITY": "80",
  "IMG_PATH": "./pics",
  "EXHAUST_PATH": "./exhaust",
  "IMG_MAP": {},
  "ALLOWED_TYPES": ["jpg","png","jpeg","bmp","svg"],
  "ENABLE_AVIF": false,
  "ENABLE_EXTRA_PARAMS": false
}

```