### PR TITLE
Add env on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ services:
     restart: always
     environment:
       - MALLOC_ARENA_MAX=1
-      # - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-      # - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4.5.6
     volumes:
       - ./path/to/pics:/opt/pics
       - ./path/to/exhaust:/opt/exhaust
@@ -83,11 +81,6 @@ services:
       - ./config.json:/etc/config.json
     ports:
       -  127.0.0.1:3333:3333
-    deploy:
-      resources:
-        limits:
-          memory: 400M
-    memswap_limit: 400M
 ```
 
 You can refer to [Docker | WebP Server Documentation](https://docs.webp.sh/usage/docker/) for more info, such as custom config, AVIF support etc.
@@ -96,7 +89,7 @@ You can refer to [Docker | WebP Server Documentation](https://docs.webp.sh/usage
 
 If you'd like to use with binary, please consult to [Use with Binary(Advanced) | WebP Server Documentation](https://docs.webp.sh/usage/usage-with-binary/)
 
->spoiler alert: you may encounter issues with `glibc` and some dependency libraries.
+> spoiler alert: you may encounter issues with `glibc` and some dependency libraries.
 
 For `supervisor` or detailed Nginx configuration, please read our documentation at [https://docs.webp.sh/](https://docs.webp.sh/)
 

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ var (
 	ProxyMode      bool
 	Prefetch       bool
 	Config         jsonFile
-	Version        = "0.9.11"
+	Version        = "0.9.12"
 	WriteLock      = cache.New(5*time.Minute, 10*time.Minute)
 	RemoteRaw      = "./remote-raw"
 	Metadata       = "./metadata"
@@ -86,9 +86,9 @@ type jsonFile struct {
 
 func init() {
 	flag.StringVar(&ConfigPath, "config", "config.json", "/path/to/config.json. (Default: ./config.json)")
-	flag.BoolVar(&Prefetch, "prefetch", false, "Prefetch and convert image to webp")
+	flag.BoolVar(&Prefetch, "prefetch", false, "Prefetch and convert image to WebP format.")
 	flag.IntVar(&Jobs, "jobs", runtime.NumCPU(), "Prefetch thread, default is all.")
-	flag.BoolVar(&DumpConfig, "dump-config", false, "Print sample config.json")
+	flag.BoolVar(&DumpConfig, "dump-config", false, "Print sample config.json.")
 	flag.BoolVar(&DumpSystemd, "dump-systemd", false, "Print sample systemd service file.")
 	flag.BoolVar(&ShowVersion, "V", false, "Show version information.")
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -191,3 +191,11 @@ func HashFile(filepath string) string {
 	buf, _ := os.ReadFile(filepath)
 	return fmt.Sprintf("%x", xxhash.Sum64(buf))
 }
+
+func GetEnv(key string, defaultVal ...string) string {
+	value := os.Getenv(key)
+	if value == "" && len(defaultVal) > 0 {
+		return defaultVal[0]
+	}
+	return value
+}

--- a/webp-server.go
+++ b/webp-server.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"webp_server_go/config"
 	"webp_server_go/encoder"
 	"webp_server_go/handler"
+	"webp_server_go/helper"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/etag"
@@ -16,11 +18,24 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var (
+	ReadBufferSizeStr   = helper.GetEnv("READ_BUFFER_SIZE", "4096") // Default: 4096
+	ReadBufferSize, _   = strconv.Atoi(ReadBufferSizeStr)
+	ConcurrencyStr      = helper.GetEnv("CONCURRENCY", "262144") // Default: 256 * 1024
+	Concurrency, _      = strconv.Atoi(ConcurrencyStr)
+	DisableKeepaliveStr = helper.GetEnv("DISABLE_KEEPALIVE", "false") // Default: false
+	DisableKeepalive, _ = strconv.ParseBool(DisableKeepaliveStr)
+)
+
+// https://docs.gofiber.io/api/fiber
 var app = fiber.New(fiber.Config{
 	ServerHeader:          "WebP Server Go",
 	AppName:               "WebP Server Go",
 	DisableStartupMessage: true,
 	ProxyHeader:           "X-Real-IP",
+	ReadBufferSize:        ReadBufferSize,   // per-connection buffer size for requests' reading. This also limits the maximum header size. Increase this buffer if your clients send multi-KB RequestURIs and/or multi-KB headers (for example, BIG cookies).
+	Concurrency:           Concurrency,      // Maximum number of concurrent connections.
+	DisableKeepalive:      DisableKeepalive, // Disable keep-alive connections, the server will close incoming connections after sending the first response to the client
 })
 
 func setupLogger() {


### PR DESCRIPTION
In this PR:
* Added `READ_BUFFER_SIZE`, `CONCURRENCY` and `DISABLE_KEEPALIVE` env when starting WebP Server Go, allows some modifications on server start, solves: https://github.com/webp-sh/webp_server_go/issues/280
* Updated README.md for better understanding
* Version bumped to 0.9.12