### PR TITLE
fix: incorrect cache key

### DIFF
--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -56,7 +56,7 @@ func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 		Id: id,
 	}
 
-	if config.ProxyMode {
+	if etag != "" {
 		data.Path = p
 		data.Checksum = HashString(etag)
 	} else {


### PR DESCRIPTION
In https://github.com/webp-sh/webp_server_go/commit/4003b030229327561b54fc26bf6fd1f72086681e, we deprecated ProxyMode switch, making this condition unavailable. We can simply detect proxy usage by the etag variable passed in.