### PR TITLE
basic health endpoint

### DIFF
--- a/handler/router.go
+++ b/handler/router.go
@@ -37,6 +37,14 @@ func Convert(c *fiber.Ctx) error {
 
 	log.Debugf("Incoming connection from %s %s %s", c.IP(), reqHostname, reqURIwithQuery)
 
+	// /health endpoint
+	if reqURI == "/health" {
+		c.SendString("UP!")
+		c.SendStatus(http.StatusOK)
+		return nil
+	}
+
+
 	if !helper.CheckAllowedType(filename) {
 		msg := "File extension not allowed! " + filename
 		log.Warn(msg)


### PR DESCRIPTION
Created a /health endpoint so this can be used in k8s with http readiness/liveness probes.
In router.go I added:
```go
	// /health endpoint
	if reqURI == "/health" {
		c.SendString("UP!")
		c.SendStatus(http.StatusOK)
		return nil
	}
```

I never used go before, but the docker image based on the Dockerfile is built and the webp server is running as it should be, /health url returns "UP!" with HTTP 200.