### PR TITLE
Add /healthz endpoint

### DIFF
--- a/handler/healthz.go
+++ b/handler/healthz.go
@@ -1,0 +1,9 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func Healthz(c *fiber.Ctx) error {
+	return c.SendString("WebP Server Go up and running!🥳")
+}

--- a/webp-server.go
+++ b/webp-server.go
@@ -85,6 +85,8 @@ func main() {
 	}))
 
 	listenAddress := config.Config.Host + ":" + config.Config.Port
+
+	app.Get("/healthz", handler.Healthz)
 	app.Get("/*", handler.Convert)
 
 	fmt.Println("WebP Server Go is Running on http://" + listenAddress)


### PR DESCRIPTION
Add `/healthz` endpoint for external healthcheck, a feature for: https://github.com/webp-sh/webp_server_go/pull/295