### PR TITLE
Fix link in README.md and fix CI permission

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,12 +79,12 @@ jobs:
         run: |
           echo "${{ steps.trivy.outputs.stdout }}"
 
-      - name: Comment PR
+      - name: Comment PR for CVE
         uses: thollander/actions-comment-pull-request@v2
-
         with:
           message: |
             ```
             ${{ steps.trivy.outputs.stdout }}
             ```
+          comment_tag: cve
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
+        permissions: 
+          pull-requests: write 
         with:
           message: |
             ```

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,6 +31,8 @@ jobs:
   image-test:
     name: Check for image build and CVE
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -79,8 +81,7 @@ jobs:
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
-        permissions: 
-          pull-requests: write 
+
         with:
           message: |
             ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now the server should be running on `127.0.0.1:3333`, visiting `http://127.0.0.1
 
 ## Custom config
 
-If you'd like to use a customized `config.json`, you can follow the steps in [Basic Usage](https://docs.webp.sh/usage/basic-usage/) to genereate one, and mount it into the container's `/etc/config.json`, example `docker-compose.yml` as follows:
+If you'd like to use a customized `config.json`, you can follow the steps in [Configuration](https://docs.webp.sh/usage/configuration/) to genereate one, and mount it into the container's `/etc/config.json`, example `docker-compose.yml` as follows:
 
 ```yml
 version: '3'


### PR DESCRIPTION
1. Fix broken link, solves https://github.com/webp-sh/webp_server_go/issues/298
2. Tries to fix CI permission, should solve the following error on https://github.com/webp-sh/webp_server_go/actions/runs/6965273052/job/18953708191 
```
Run thollander/actions-comment-pull-request@v2
  with:
    message: 
  
  ghcr.io/webp-sh/webp_server_go (debian 1[2](https://github.com/webp-sh/webp_server_go/actions/runs/6965273052/job/18953708191#step:9:2).2)
  ============================================
  Total: 0 (HIGH: 0, CRITICAL: 0)
  
  
    GITHUB_TOKEN: ***
    mode: upsert
    create_if_not_exists: true
Error: Resource not accessible by integration
```