### PR TITLE
Ignore GIF when converting to AVIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This is a Server based on Golang, which allows you to serve WebP images on the f
 
 Currently supported image format: JPEG, PNG, BMP, GIF, SVG, HEIC, NEF
 
-> e.g When you visit `https://your.website/pics/tsuki.jpg`，it will serve as `image/webp` format without changing the URL.
+> e.g When you visit `https://your.website/pics/tsuki.jpg`，it will serve as `image/webp`/`image/avif` format without changing the URL.
+>
+> GIF image will not be converted to AVIF format even with `ENABLE_AVIF` to `true`, because the converted AVIF image is not animated.
 
 ## Usage with Docker(recommended)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 This is a Server based on Golang, which allows you to serve WebP images on the fly.
 
-Currently supported image format: JPEG, PNG, BMP, GIF, SVG, HEIC, NEF
+Currently supported image format: JPEG, PNG, BMP, GIF, SVG, HEIC, NEF, WEBP
 
 > e.g When you visit `https://your.website/pics/tsuki.jpg`，it will serve as `image/webp`/`image/avif` format without changing the URL.
 >

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func NewWebPConfig() *WebpConfig {
 		Port:              "3333",
 		ImgPath:           "./pics",
 		Quality:           80,
-		AllowedTypes:      []string{"jpg", "png", "jpeg", "bmp", "svg", "nef"},
+		AllowedTypes:      []string{"jpg", "png", "jpeg", "bmp", "svg", "nef", "heic"},
 		ImageMap:          map[string]string{},
 		ExhaustPath:       "./exhaust",
 		EnableAVIF:        false,

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func NewWebPConfig() *WebpConfig {
 		Port:              "3333",
 		ImgPath:           "./pics",
 		Quality:           80,
-		AllowedTypes:      []string{"jpg", "png", "jpeg", "bmp", "svg", "nef", "heic"},
+		AllowedTypes:      []string{"jpg", "png", "jpeg", "bmp", "svg", "nef", "heic", "webp"},
 		ImageMap:          map[string]string{},
 		ExhaustPath:       "./exhaust",
 		EnableAVIF:        false,

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -18,7 +18,9 @@ var (
 	boolFalse   vips.BoolParameter
 	intMinusOne vips.IntParameter
 	// Source image encoder ignore list for WebP and AVIF
+	// We shouldn't convert Unknown and AVIF to WebP
 	webpIgnore = []vips.ImageType{vips.ImageTypeUnknown, vips.ImageTypeAVIF}
+	// We shouldn't convert Unknown,AVIF and GIF to AVIF
 	avifIgnore = append(webpIgnore, vips.ImageTypeGIF)
 )
 


### PR DESCRIPTION
Solves: https://github.com/webp-sh/webp_server_go/issues/301

Changes:
1. Allow WebP image format as source
2. Disabled GIF to AVIF conversion