### PR TITLE
Lock on convert

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ var (
 	ProxyMode      bool
 	Prefetch       bool
 	Config         = NewWebPConfig()
-	Version        = "0.10.4"
+	Version        = "0.10.5"
 	WriteLock      = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock    = cache.New(5*time.Minute, 10*time.Minute)
 	RemoteRaw      = "./remote-raw"

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ var (
 	Config         = NewWebPConfig()
 	Version        = "0.10.4"
 	WriteLock      = cache.New(5*time.Minute, 10*time.Minute)
+	ConvertLock    = cache.New(5*time.Minute, 10*time.Minute)
 	RemoteRaw      = "./remote-raw"
 	Metadata       = "./metadata"
 	LocalHostAlias = "local"

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -39,7 +39,7 @@ func ConvertFilter(rawPath, avifPath, webpPath string, extraParams config.ExtraP
 
 	for {
 		if _, found := config.ConvertLock.Get(rawPath); found {
-			log.Infof("file %s is locked under conversion, retrying in %s", rawPath, retryDelay)
+			log.Debugf("file %s is locked under conversion, retrying in %s", rawPath, retryDelay)
 			time.Sleep(retryDelay)
 		} else {
 			// The lock is released, indicating that the conversion is complete

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -48,7 +48,7 @@ func ConvertFilter(rawPath, avifPath, webpPath string, extraParams config.ExtraP
 	}
 
 	// If there is a lock here, it means that another thread is converting the same image
-	// Lock rawPath to prevent concurrent convertion
+	// Lock rawPath to prevent concurrent conversion
 	config.ConvertLock.Set(rawPath, true, -1)
 	defer config.ConvertLock.Delete(rawPath)
 
@@ -95,9 +95,9 @@ func convertImage(rawPath, optimizedPath, imageType string, extraParams config.E
 		var convertedRaw, converted = ConvertRawToJPG(rawPath, optimizedPath)
 		// If converted, use converted file as raw
 		if converted {
-			// Use converted file(JPG) as raw input for further convertion
+			// Use converted file(JPG) as raw input for further conversion
 			rawPath = convertedRaw
-			// Remove converted file after convertion
+			// Remove converted file after conversion
 			defer func() {
 				log.Infoln("Removing intermediate conversion file:", convertedRaw)
 				err := os.Remove(convertedRaw)


### PR DESCRIPTION
In some cases when multiple concurrent requests are made to WebP Server, for example to a image with size of 10MiB, when the conversion is on-going, WebP Server will spawn multiple threads per request to convert the same image, which is not good and can exhaust all server resources in some condition.

This PR added a Lock called `ConvertLock` to prevent this from happening, thus there will be only one thread for converting a specific image at any given moment.