### PR TITLE
Add EXTRA_PARAMS_CROP_INTERESTING

### DIFF
--- a/encoder/process.go
+++ b/encoder/process.go
@@ -63,7 +63,27 @@ func resizeImage(img *vips.ImageRef, extraParams config.ExtraParams) error {
 	}
 
 	if extraParams.Width > 0 && extraParams.Height > 0 {
-		err := img.Thumbnail(extraParams.Width, extraParams.Height, vips.InterestingAttention)
+		var cropInteresting vips.Interesting
+		switch config.Config.ExtraParamsCropInteresting {
+		case "InterestingNone":
+			cropInteresting = vips.InterestingNone
+		case "InterestingCentre":
+			cropInteresting = vips.InterestingCentre
+		case "InterestingEntropy":
+			cropInteresting = vips.InterestingEntropy
+		case "InterestingAttention":
+			cropInteresting = vips.InterestingAttention
+		case "InterestingLow":
+			cropInteresting = vips.InterestingLow
+		case "InterestingHigh":
+			cropInteresting = vips.InterestingHigh
+		case "InterestingAll":
+			cropInteresting = vips.InterestingAll
+		default:
+			cropInteresting = vips.InterestingAttention
+		}
+
+		err := img.Thumbnail(extraParams.Width, extraParams.Height, cropInteresting)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Related to: https://github.com/webp-sh/webp_server_go/issues/327

This PR will add a config parameter called `EXTRA_PARAMS_CROP_INTERESTING` in `config.json`, and `WEBP_EXTRA_PARAMS_CROP_INTERESTING` in environment variable.

Available options for `EXTRA_PARAMS_CROP_INTERESTING` are:
* InterestingNone
* InterestingCentre
* InterestingEntropy
* InterestingAttention
* InterestingLow
* InterestingHigh
* InterestingAll

This will allow users to select what kind of crop interest when using EXTRA_PARAMS and both width and height are supplied.

More about Extra Parameters: https://docs.webp.sh/usage/extra-params/#extra-parameters
More examples about different Interesting: https://blog.webp.se/vips-crop-en/