### PR TITLE
Add `MAX_CACHE_SIZE` config

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22'
 
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build image
         uses: docker/build-push-action@v3
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build image
         uses: docker/build-push-action@v3

--- a/.github/workflows/release_binary.yaml
+++ b/.github/workflows/release_binary.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Make WebP Server Go (amd64)
         run: |

--- a/.github/workflows/release_docker_image.yaml
+++ b/.github/workflows/release_docker_image.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tools-dir:
 
 install-staticcheck: tools-dir
 	GOBIN=`pwd`/tools/bin go install honnef.co/go/tools/cmd/staticcheck@latest
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.52.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.59.1
 
 static-check: install-staticcheck
 	#S1000,SA1015,SA4006,SA4011,S1023,S1034,ST1003,ST1005,ST1016,ST1020,ST1021
@@ -38,7 +38,6 @@ test:
 
 clean:
 	rm -rf prefetch remote-raw exhaust tools coverage.txt metadata exhaust_test
-
 
 docker:
 	DOCKER_BUILDKIT=1 docker build -t webpsh/webps .

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -126,10 +126,18 @@ func convertImage(rawPath, optimizedPath, imageType string, extraParams config.E
 		FailOnError: boolFalse,
 		NumPages:    intMinusOne,
 	})
+	if err != nil {
+		log.Warnf("Can't open source image: %v", err)
+		return err
+	}
 	defer img.Close()
 
 	// Pre-process image(auto rotate, resize, etc.)
-	preProcessImage(img, imageType, extraParams)
+	err = preProcessImage(img, imageType, extraParams)
+	if err != nil {
+		log.Warnf("Can't pre-process source image: %v", err)
+		return err
+	}
 
 	switch imageType {
 	case "webp":

--- a/handler/remote.go
+++ b/handler/remote.go
@@ -80,9 +80,9 @@ func fetchRemoteImg(url string, subdir string) config.MetaFile {
 	// url is https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 	// How do we know if the remote img is changed? we're using hash(etag+length)
 	var etag string
-	
-	cacheKey := subdir+":"+helper.HashString(url)
-	
+
+	cacheKey := subdir + ":" + helper.HashString(url)
+
 	if val, found := config.RemoteCache.Get(cacheKey); found {
 		if etagVal, ok := val.(string); ok {
 			log.Infof("Using cache for remote addr: %s", url)
@@ -90,8 +90,8 @@ func fetchRemoteImg(url string, subdir string) config.MetaFile {
 		} else {
 			config.RemoteCache.Delete(cacheKey)
 		}
-	} 
-	
+	}
+
 	if etag == "" {
 		log.Infof("Remote Addr is %s, pinging for info...", url)
 		etag = pingURL(url)
@@ -99,12 +99,13 @@ func fetchRemoteImg(url string, subdir string) config.MetaFile {
 			config.RemoteCache.Set(cacheKey, etag, cache.DefaultExpiration)
 		}
 	}
-	
+
 	metadata := helper.ReadMetadata(url, etag, subdir)
-	localRawImagePath := path.Join(config.RemoteRaw, subdir, metadata.Id)
+	localRawImagePath := path.Join(config.Config.RemoteRawPath, subdir, metadata.Id)
+	localExhaustImagePath := path.Join(config.Config.ExhaustPath, subdir, metadata.Id)
 
 	if !helper.ImageExists(localRawImagePath) || metadata.Checksum != helper.HashString(etag) {
-		cleanProxyCache(path.Join(config.Config.ExhaustPath, subdir, metadata.Id+"*"))
+		cleanProxyCache(localExhaustImagePath)
 		if metadata.Checksum != helper.HashString(etag) {
 			// remote file has changed
 			log.Info("Remote file changed, updating metadata and fetching image source...")

--- a/handler/router.go
+++ b/handler/router.go
@@ -123,7 +123,7 @@ func Convert(c *fiber.Ctx) error {
 		// https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 
 		metadata = fetchRemoteImg(realRemoteAddr, targetHostName)
-		rawImageAbs = path.Join(config.RemoteRaw, targetHostName, metadata.Id)
+		rawImageAbs = path.Join(config.Config.RemoteRawPath, targetHostName, metadata.Id)
 	} else {
 		// not proxyMode, we'll use local path
 		metadata = helper.ReadMetadata(reqURIwithQuery, "", targetHostName)

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -33,8 +33,8 @@ func setupParam() {
 	config.Config.ImgPath = "../pics"
 	config.Config.ExhaustPath = "../exhaust_test"
 	config.Config.AllowedTypes = []string{"jpg", "png", "jpeg", "bmp"}
-	config.Metadata = "../metadata"
-	config.RemoteRaw = "../remote-raw"
+	config.Config.MetadataPath = "../metadata"
+	config.Config.RemoteRawPath = "../remote-raw"
 	config.ProxyMode = false
 	config.Config.EnableWebP = true
 	config.Config.EnableAVIF = false

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -90,10 +90,7 @@ func CheckAllowedType(imgFilename string) bool {
 	}
 	imgFilenameExtension := strings.ToLower(path.Ext(imgFilename))
 	imgFilenameExtension = strings.TrimPrefix(imgFilenameExtension, ".") // .jpg -> jpg
-	if slices.Contains(config.Config.AllowedTypes, imgFilenameExtension) {
-		return true
-	}
-	return false
+	return slices.Contains(config.Config.AllowedTypes, imgFilenameExtension)
 }
 
 func GenOptimizedAbsPath(metadata config.MetaFile, subdir string) (string, string, string) {

--- a/schedule/cache_clean.go
+++ b/schedule/cache_clean.go
@@ -90,21 +90,26 @@ func clearCacheFiles(path string, maxCacheSizeBytes int64) error {
 
 func CleanCache() {
 	log.Info("MaxCacheSize is not 0, starting cache cleaning service")
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
 	for {
-		// MB to bytes
-		maxCacheSizeBytes := int64(config.Config.MaxCacheSize) * 1024 * 1024
-		err := clearCacheFiles(config.Config.RemoteRawPath, maxCacheSizeBytes)
-		if err != nil {
-			log.Warn("Failed to clear remote raw cache")
+		select {
+		case <-ticker.C:
+			// MB to bytes
+			maxCacheSizeBytes := int64(config.Config.MaxCacheSize) * 1024 * 1024
+			err := clearCacheFiles(config.Config.RemoteRawPath, maxCacheSizeBytes)
+			if err != nil {
+				log.Warn("Failed to clear remote raw cache")
+			}
+			err = clearCacheFiles(config.Config.ExhaustPath, maxCacheSizeBytes)
+			if err != nil && err != os.ErrNotExist {
+				log.Warn("Failed to clear remote raw cache")
+			}
+			err = clearCacheFiles(config.Config.MetadataPath, maxCacheSizeBytes)
+			if err != nil && err != os.ErrNotExist {
+				log.Warn("Failed to clear remote raw cache")
+			}
 		}
-		err = clearCacheFiles(config.Config.ExhaustPath, maxCacheSizeBytes)
-		if err != nil && err != os.ErrNotExist {
-			log.Warn("Failed to clear remote raw cache")
-		}
-		err = clearCacheFiles(config.Config.MetadataPath, maxCacheSizeBytes)
-		if err != nil && err != os.ErrNotExist {
-			log.Warn("Failed to clear remote raw cache")
-		}
-		time.Sleep(1 * time.Minute)
 	}
 }

--- a/schedule/cache_clean.go
+++ b/schedule/cache_clean.go
@@ -1,0 +1,110 @@
+package schedule
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+	"webp_server_go/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func getDirSize(path string) (int64, error) {
+	// Check if path is a directory and exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return 0, nil
+	}
+	var size int64
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
+// Delete the oldest file in the given path
+func clearDirForOldestFiles(path string) error {
+	oldestFile := ""
+	oldestModTime := time.Now()
+
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Errorf("Error accessing path %s: %s\n", path, err.Error())
+			return nil
+		}
+
+		if !info.IsDir() && info.ModTime().Before(oldestModTime) {
+			oldestFile = path
+			oldestModTime = info.ModTime()
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Errorf("Error traversing directory: %s\n", err.Error())
+		return err
+	}
+
+	if oldestFile != "" {
+		err := os.Remove(oldestFile)
+		if err != nil {
+			log.Errorf("Error deleting file %s: %s\n", oldestFile, err.Error())
+			return err
+		}
+		log.Infof("Deleted oldest file: %s\n", oldestFile)
+	} else {
+		log.Infoln("No files found in the directory.")
+	}
+	return nil
+}
+
+// Clear cache, size is in bytes that needs to be cleared out
+// Will delete oldest files first, then second oldest, etc.
+// Until all files size are less than maxCacheSizeBytes
+func clearCacheFiles(path string, maxCacheSizeBytes int64) error {
+	dirSize, err := getDirSize(path)
+	if err != nil {
+		log.Errorf("Error getting directory size: %s\n", err.Error())
+		return err
+	}
+
+	for dirSize > maxCacheSizeBytes {
+		err := clearDirForOldestFiles(path)
+		if err != nil {
+			log.Errorf("Error clearing directory: %s\n", err.Error())
+			return err
+		}
+		dirSize, err = getDirSize(path)
+		if err != nil {
+			log.Errorf("Error getting directory size: %s\n", err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func CleanCache() {
+	log.Info("MaxCacheSize is not 0, starting cache cleaning service")
+	for {
+		// MB to bytes
+		maxCacheSizeBytes := int64(config.Config.MaxCacheSize) * 1024 * 1024
+		err := clearCacheFiles(config.Config.RemoteRawPath, maxCacheSizeBytes)
+		if err != nil {
+			log.Warn("Failed to clear remote raw cache")
+		}
+		err = clearCacheFiles(config.Config.ExhaustPath, maxCacheSizeBytes)
+		if err != nil && err != os.ErrNotExist {
+			log.Warn("Failed to clear remote raw cache")
+		}
+		err = clearCacheFiles(config.Config.MetadataPath, maxCacheSizeBytes)
+		if err != nil && err != os.ErrNotExist {
+			log.Warn("Failed to clear remote raw cache")
+		}
+		time.Sleep(1 * time.Minute)
+	}
+}

--- a/webp-server.go
+++ b/webp-server.go
@@ -8,6 +8,7 @@ import (
 	"webp_server_go/config"
 	"webp_server_go/encoder"
 	"webp_server_go/handler"
+	schedule "webp_server_go/schedule"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/etag"
@@ -80,6 +81,9 @@ func init() {
 }
 
 func main() {
+	if config.Config.MaxCacheSize != 0 {
+		go schedule.CleanCache()
+	}
 	if config.Prefetch {
 		go encoder.PrefetchImages()
 	}


### PR DESCRIPTION
This PR adds `MAX_CACHE_SIZE` in config, which will solve the following issues:
* https://github.com/webp-sh/webp_server_go/issues/285
* https://github.com/webp-sh/webp_server_go/issues/282
* https://github.com/webp-sh/webp_server_go/issues/214
* https://github.com/webp-sh/webp_server_go/issues/342

`MAX_CACHE_SIZE` is set in number, with unit of MiB, the default value is 0, which will remain current setup, if this value is set, for example 50, then a background task will run alongside with WebP Server Go, that task will ensure the following directories will be below 50MiB, seperately.
* `./metadata`
* `./exhaust`
* `./remote-raw`

If any of the above directories' size goes above setting value, the oldest file will be deleted to make space.

Note, this will keep the above directories' size **seperately**, so there can be the following situation with total size of 101MiB.
* `./metadata` (4MiB)
* `./exhaust`  (48MiB)
* `./remote-raw`  (49MiB)

Also, this PR fixes a bug where `CACHE_TTL` should be `WEBP_CACHE_TTL` in environment variable.