### PR TITLE
Use newer version of libaom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ FROM debian:bookworm-slim
 
 RUN apt update && apt install --no-install-recommends libvips ca-certificates libjemalloc2 libtcmalloc-minimal4 -y && rm -rf /var/lib/apt/lists/* &&  rm -rf /var/cache/apt/archives/*
 
+# Download and install libam with correct arch
+# http://ftp.us.debian.org/debian/pool/main/a/aom/libaom3_3.11.0~rc1-1_amd64.deb
+# http://ftp.us.debian.org/debian/pool/main/a/aom/libaom3_3.11.0~rc1-1_arm64.deb
+RUN curl -O http://ftp.us.debian.org/debian/pool/main/a/aom/libaom3_3.11.0~rc1-1_$(dpkg --print-architecture).deb && \
+    dpkg -i libaom3_3.11.0~rc1-1_$(dpkg --print-architecture).deb && \
+    rm libaom3_3.11.0~rc1-1_$(dpkg --print-architecture).deb
+
 COPY --from=builder /build/webp-server  /usr/bin/webp-server
 COPY --from=builder /build/config.json /etc/config.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /build && sed -i "s|.\/pics|${IMG_PATH}|g" config.json  \
 
 FROM debian:bookworm-slim
 
-RUN apt update && apt install --no-install-recommends libvips ca-certificates libjemalloc2 libtcmalloc-minimal4 -y && rm -rf /var/lib/apt/lists/* &&  rm -rf /var/cache/apt/archives/*
+RUN apt update && apt install --no-install-recommends libvips ca-certificates libjemalloc2 libtcmalloc-minimal4 curl -y && rm -rf /var/lib/apt/lists/* &&  rm -rf /var/cache/apt/archives/*
 
 # Download and install libam with correct arch
 # http://ftp.us.debian.org/debian/pool/main/a/aom/libaom3_3.11.0~rc1-1_amd64.deb


### PR DESCRIPTION
`debian:bookworm-slim` comes with libaom-dev/now 3.6.0-1, however this version might cause problems when converting some images to AVIF, we've found this problem on [WebP Cloud](https://webp.se) and wish to port this patch to WebP Server Go.