### PR TITLE
Customize loglevel with `--verbosity` flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ var (
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.13.0"
+	Version             = "0.13.1"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ const (
 var (
 	ConfigPath          string
 	Jobs                int
+	Verbosity           int
 	DumpSystemd         bool
 	DumpConfig          bool
 	ShowVersion         bool
@@ -144,6 +145,12 @@ func init() {
 	flag.BoolVar(&Prefetch, "prefetch", false, "Prefetch and convert images to optimized format, with WebP Server Go launch normally")
 	flag.BoolVar(&PrefetchForeground, "prefetch-foreground", false, "Prefetch and convert image to optimized format in foreground, prefetch and exit")
 	flag.IntVar(&Jobs, "jobs", runtime.NumCPU(), "Prefetch thread, default is all.")
+	// 0 = silent (no log messages)
+	// 1 = error (error messages only)
+	// 2 = warn (error messages and warnings only)
+	// 3 = info (error messages, warnings and normal activity logs)
+	// 4 = debug (all info plus additional messages for debugging)
+	flag.IntVar(&Verbosity, "verbosity", 3, "Log level(0: silent, 1: error, 2: warn, 3:info, 4: debug), default to 3: info")
 	flag.BoolVar(&DumpConfig, "dump-config", false, "Print sample config.json.")
 	flag.BoolVar(&ShowVersion, "V", false, "Show version information.")
 }

--- a/webp-server.go
+++ b/webp-server.go
@@ -40,13 +40,7 @@ func setupLogger() {
 		},
 	}
 	log.SetFormatter(formatter)
-	log.SetLevel(log.InfoLevel)
 
-	// fiber logger format
-	app.Use(logger.New(logger.Config{
-		Format:     config.FiberLogFormat,
-		TimeFormat: config.TimeDateFormat,
-	}))
 	app.Use(recover.New(recover.Config{}))
 	fmt.Println("Allowed file types as source:", config.Config.AllowedTypes)
 	fmt.Println("Convert to WebP Enabled:", config.Config.EnableWebP)
@@ -66,6 +60,29 @@ func init() {
 		Developed by WebP Server team. https://github.com/webp-sh`, config.Version)
 	// main init is the last one to be called
 	flag.Parse()
+	loglevel := config.Verbosity
+
+	// Only enable fiber logger if loglevel is greater than 0
+	if loglevel > 0 {
+		// fiber logger format
+		app.Use(logger.New(logger.Config{
+			Format:     config.FiberLogFormat,
+			TimeFormat: config.TimeDateFormat,
+		}))
+	}
+
+	switch loglevel {
+	case 0:
+		log.SetLevel(log.PanicLevel)
+	case 1:
+		log.SetLevel(log.ErrorLevel)
+	case 2:
+		log.SetLevel(log.WarnLevel)
+	case 3:
+		log.SetLevel(log.InfoLevel)
+	case 4:
+		log.SetLevel(log.DebugLevel)
+	}
 	// process cli params
 	if config.DumpConfig {
 		fmt.Println(config.SampleConfig)


### PR DESCRIPTION
0 = silent (no log messages)
1 = error (error messages only)
2 = warn (error messages and warnings only)
3 = info (error messages, warnings and normal activity logs)
4 = debug (all info plus additional messages for debugging)
