### PR TITLE
Correctly handle non-image file when using remote backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ var (
 	DumpConfig          bool
 	ShowVersion         bool
 	ProxyMode           bool
+	AllowAllExtensions  bool
 	Prefetch            bool // Prefech in go-routine, with WebP Server Go launch normally
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
@@ -298,6 +299,10 @@ func LoadConfig() {
 		} else {
 			Config.MaxCacheSize = maxCacheSize
 		}
+	}
+
+	if Config.AllowedTypes[0] == "*" {
+		AllowAllExtensions = true
 	}
 
 	log.Debugln("Config init complete")

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ var (
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.13.2"
+	Version             = "0.13.3"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"

--- a/handler/remote.go
+++ b/handler/remote.go
@@ -54,8 +54,8 @@ func downloadFile(filepath string, url string) {
 	// Check if remote content-type is image using check by filetype instead of content-type returned by origin
 	kind, _ := filetype.Match(bodyBytes.Bytes())
 	mime := kind.MIME.Value
-	if !strings.Contains(mime, "image") {
-		log.Errorf("remote file %s is not image, remote content has MIME type of %s", url, mime)
+	if !strings.Contains(mime, "image") && !config.AllowAllExtensions {
+		log.Errorf("remote file %s is not image and AllowedTypes is not '*', remote content has MIME type of %s", url, mime)
 		return
 	}
 
@@ -126,7 +126,7 @@ func pingURL(url string) string {
 	var etag, length string
 	resp, err := http.Head(url)
 	if err != nil {
-		log.Errorln("Connection to remote error when pingUrl!")
+		log.Errorln("Connection to remote error when pingUrl:"+url, err)
 		return ""
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
When `ALLOWED_TYPES` is set to `*` and `IMG_PATH` is using a remote address can cause bug behavior like stated in https://github.com/webp-sh/webp_server_go/issues/381, this PR tries to fix this.

Should fix https://github.com/webp-sh/webp_server_go/issues/381