### PR TITLE
Drop old version of glibc

### DIFF
--- a/.github/workflows/release_binary.yaml
+++ b/.github/workflows/release_binary.yaml
@@ -10,34 +10,67 @@ on:
       - '*'
 
 jobs:
-  build:
-    name: Create Release
-    runs-on: ubuntu-latest
+  build-amd64:
+    name: Create AMD64 Binary
+    runs-on: ubuntu-22.04 # Using 22.04 of ubuntu to get the lowest version of glibc
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Make WebP Server Go (amd64)
+      
+      - name: Install dependencies
         run: |
-          docker run --rm -w /app -v "$(pwd)":/app webpsh/libvips make
-          sudo chown -R $USER:$USER builds/
-          sha256sum builds/webp-server-linux-amd64 > builds/webp-server-linux-amd64.sha256
-
-      - name: Make WebP Server Go (arm64)
+          sudo apt update && sudo apt install --no-install-recommends libvips-dev -y
+      
+      - name: Make
         run: |
-          docker run --rm -w /app -v "$(pwd)":/app --platform linux/arm64 webpsh/libvips make
-          sudo chown -R $USER:$USER builds/
-          sha256sum builds/webp-server-linux-arm64 > builds/webp-server-linux-arm64.sha256
+          make
+          
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: webp-server-linux-amd64
+          path: builds/webp-server-linux-amd64
 
-      - name: Check for ldd version(AMD64 only)
+
+  build-arm64:
+    name: Create ARM64 Binary
+    runs-on: ubuntu-22.04-arm # Using 22.04 of ubuntu to get the lowest version of glibc
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install dependencies
         run: |
-          ldd builds/webp-server-linux-amd64
+          sudo apt update && sudo apt install --no-install-recommends libvips-dev -y
+      
+      - name: Make
+        run: |
+          make
+          
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: webp-server-linux-arm64
+  
+  release-binary:
+    name: Release Binary
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Download Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: webp-server-linux-amd64
+      
+      - name: Download Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: webp-server-linux-arm64
+      
+      - name: Get SHA256
+        run: |
+          sha256sum webp-server-linux-amd64 > webp-server-linux-amd64.sha256
+          sha256sum webp-server-linux-arm64 >webp-server-linux-arm64.sha256
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
@@ -45,7 +78,7 @@ jobs:
           prerelease: true
           title: "WebP Server Go"
           files: |
-            builds/webp-server-linux-amd64
-            builds/webp-server-linux-amd64.sha256
-            builds/webp-server-linux-arm64
-            builds/webp-server-linux-arm64.sha256
+            webp-server-linux-amd64
+            webp-server-linux-amd64.sha256
+            webp-server-linux-arm64
+            webp-server-linux-arm64.sha256


### PR DESCRIPTION
Using old version of glibc with CentOS 7 image won't compile(https://github.com/webp-sh/webp_server_go/actions/runs/13534405190/job/37823287393), we should drop that support now.