### PR TITLE
Partial fix for bugs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ var (
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.13.3"
+	Version             = "0.13.4"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"

--- a/handler/remote.go
+++ b/handler/remote.go
@@ -104,7 +104,8 @@ func fetchRemoteImg(url string, subdir string) (metaContent config.MetaFile, res
 	}
 
 	metadata := helper.ReadMetadata(url, etag, subdir)
-	localRawImagePath := path.Join(config.Config.RemoteRawPath, subdir, metadata.Id)
+	remoteFileExtension := path.Ext(url)
+	localRawImagePath := path.Join(config.Config.RemoteRawPath, subdir, metadata.Id) + remoteFileExtension
 	localExhaustImagePath := path.Join(config.Config.ExhaustPath, subdir, metadata.Id)
 
 	if !helper.ImageExists(localRawImagePath) || metadata.Checksum != helper.HashString(etag) {
@@ -119,6 +120,8 @@ func fetchRemoteImg(url string, subdir string) (metaContent config.MetaFile, res
 			log.Info("Remote file not found in remote-raw, re-fetching...")
 		}
 		header = downloadFile(localRawImagePath, url)
+		// Update metadata with newly downloaded file
+		helper.WriteMetadata(url, etag, subdir)
 	}
 	return metadata, header
 }

--- a/handler/remote.go
+++ b/handler/remote.go
@@ -78,11 +78,10 @@ func downloadFile(filepath string, url string) http.Header {
 	return resp.Header
 }
 
-func fetchRemoteImg(url string, subdir string) (metaContent config.MetaFile, respHeader http.Header) {
+func fetchRemoteImg(url string, subdir string) (metaContent config.MetaFile) {
 	// url is https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 	// How do we know if the remote img is changed? we're using hash(etag+length)
 	var etag string
-	var header http.Header
 
 	cacheKey := subdir + ":" + helper.HashString(url)
 
@@ -119,11 +118,11 @@ func fetchRemoteImg(url string, subdir string) (metaContent config.MetaFile, res
 			// local file not exists
 			log.Info("Remote file not found in remote-raw, re-fetching...")
 		}
-		header = downloadFile(localRawImagePath, url)
+		_ = downloadFile(localRawImagePath, url)
 		// Update metadata with newly downloaded file
 		helper.WriteMetadata(url, etag, subdir)
 	}
-	return metadata, header
+	return metadata
 }
 
 func pingURL(url string) string {

--- a/handler/router.go
+++ b/handler/router.go
@@ -125,9 +125,8 @@ func Convert(c *fiber.Ctx) error {
 			return c.SendFile(path.Join(config.Config.ImgPath, reqURI))
 		} else {
 			// If the file is not in the ImgPath, we'll have to use the proxy mode to download it
-			_, respHeader := fetchRemoteImg(realRemoteAddr, targetHostName)
-			localFilename := path.Join(config.Config.RemoteRawPath, targetHostName, helper.HashString(realRemoteAddr))
-			c.Set("Content-Type", string(respHeader.Get("Content-Type")))
+			_ = fetchRemoteImg(realRemoteAddr, targetHostName)
+			localFilename := path.Join(config.Config.RemoteRawPath, targetHostName, helper.HashString(realRemoteAddr)) + path.Ext(realRemoteAddr)
 			return c.SendFile(localFilename)
 		}
 	}
@@ -138,7 +137,7 @@ func Convert(c *fiber.Ctx) error {
 		// this is proxyMode, we'll have to use this url to download and save it to local path, which also gives us rawImageAbs
 		// https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 
-		metadata, _ = fetchRemoteImg(realRemoteAddr, targetHostName)
+		metadata = fetchRemoteImg(realRemoteAddr, targetHostName)
 		rawImageAbs = path.Join(config.Config.RemoteRawPath, targetHostName, metadata.Id) + path.Ext(realRemoteAddr)
 	} else {
 		// not proxyMode, we'll use local path

--- a/handler/router.go
+++ b/handler/router.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -114,7 +113,7 @@ func Convert(c *fiber.Ctx) error {
 
 		// Replace host in the URL
 		// realRemoteAddr = strings.Replace(reqURIwithQuery, reqHost, targetHost, 1)
-		realRemoteAddr = targetHost + reqURIwithQuery
+		realRemoteAddr, _ = url.JoinPath(targetHost, reqURIwithQuery)
 		log.Debugf("realRemoteAddr is %s", realRemoteAddr)
 	}
 
@@ -127,7 +126,6 @@ func Convert(c *fiber.Ctx) error {
 		} else {
 			// If the file is not in the ImgPath, we'll have to use the proxy mode to download it
 			_, respHeader := fetchRemoteImg(realRemoteAddr, targetHostName)
-			fmt.Println("respHeader", respHeader)
 			localFilename := path.Join(config.Config.RemoteRawPath, targetHostName, helper.HashString(realRemoteAddr))
 			c.Set("Content-Type", string(respHeader.Get("Content-Type")))
 			return c.SendFile(localFilename)
@@ -141,7 +139,7 @@ func Convert(c *fiber.Ctx) error {
 		// https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 
 		metadata, _ = fetchRemoteImg(realRemoteAddr, targetHostName)
-		rawImageAbs = path.Join(config.Config.RemoteRawPath, targetHostName, metadata.Id)
+		rawImageAbs = path.Join(config.Config.RemoteRawPath, targetHostName, metadata.Id) + path.Ext(realRemoteAddr)
 	} else {
 		// not proxyMode, we'll use local path
 		metadata = helper.ReadMetadata(reqURIwithQuery, "", targetHostName)

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -293,6 +293,24 @@ func TestConvertProxyModeWork(t *testing.T) {
 	assert.Equal(t, "image/jpeg", helper.GetContentType(data))
 }
 
+func TestConvertProxyModeNonImageWork(t *testing.T) {
+	setupParam()
+	config.ProxyMode = true
+	config.Config.AllowedTypes = []string{"*"}
+	config.AllowAllExtensions = true
+	config.Config.ImgPath = "https://docs.webp.sh"
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	url := "http://127.0.0.1:3333/sw.js"
+
+	resp, _ := requestToServer(url, app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/javascript; charset=utf-8", resp.Header.Get("Content-Type"))
+}
+
 func TestConvertMapProxyModeWork(t *testing.T) {
 	setupParam()
 	config.ProxyMode = true

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -293,6 +293,30 @@ func TestConvertProxyModeWork(t *testing.T) {
 	assert.Equal(t, "image/jpeg", helper.GetContentType(data))
 }
 
+func TestConvertMapProxyModeWork(t *testing.T) {
+	setupParam()
+	config.ProxyMode = true
+	config.Config.ImageMap = map[string]string{
+		"/": "https://docs.webp.sh",
+	}
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	url := "http://127.0.0.1:3333/images/webp_server.jpg"
+
+	resp, data := requestToServer(url, app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/webp", helper.GetContentType(data))
+
+	// test proxyMode with Safari
+	resp, data = requestToServer(url, app, safariUA, acceptLegacy)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/jpeg", helper.GetContentType(data))
+}
+
 func TestConvertProxyImgMap(t *testing.T) {
 	setupParam()
 	config.ProxyMode = false
@@ -379,7 +403,7 @@ func TestConvertProxyImgMapCWD(t *testing.T) {
 	}
 }
 
-func TestConvertBigger(t *testing.T) {
+func TestConvertedFileIsBigger(t *testing.T) {
 	setupParam()
 	config.Config.Quality = 100
 

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -70,9 +69,6 @@ func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 		data.Path = sant
 		data.Checksum = HashFile(filepath)
 	}
-
-	fmt.Println("p", p)
-	fmt.Println("getImageMeta(filepath)", filepath)
 
 	imageMeta := getImageMeta(filepath)
 

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -13,10 +13,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func getId(p string) (string, string, string) {
-	var id string
+// Get ID and filepath
+// For ProxyMode, pass in p the remote-raw path
+func getId(p string, subdir string) (id string, filePath string, santizedPath string) {
 	if config.ProxyMode {
-		return HashString(p), "", ""
+		fileID := HashString(p)
+		return fileID, path.Join(config.Config.RemoteRawPath, subdir, fileID) + path.Ext(p), ""
 	}
 	parsed, _ := url.Parse(p)
 	width := parsed.Query().Get("width")
@@ -25,16 +27,17 @@ func getId(p string) (string, string, string) {
 	max_height := parsed.Query().Get("max_height")
 	// santizedPath will be /webp_server.jpg?width=200\u0026height=\u0026max_width=\u0026max_height= in local mode when requesting /webp_server.jpg?width=200
 	// santizedPath will be https://docs.webp.sh/images/webp_server.jpg?width=400 in proxy mode when requesting /images/webp_server.jpg?width=400 with IMG_PATH = https://docs.webp.sh
-	santizedPath := parsed.Path + "?width=" + width + "&height=" + height + "&max_width=" + max_width + "&max_height=" + max_height
+	santizedPath = parsed.Path + "?width=" + width + "&height=" + height + "&max_width=" + max_width + "&max_height=" + max_height
 	id = HashString(santizedPath)
+	filePath = path.Join(config.Config.ImgPath, parsed.Path)
 
-	return id, path.Join(config.Config.ImgPath, parsed.Path), santizedPath
+	return id, filePath, santizedPath
 }
 
 func ReadMetadata(p, etag string, subdir string) config.MetaFile {
 	// try to read metadata, if we can't read, create one
 	var metadata config.MetaFile
-	var id, _, _ = getId(p)
+	var id, _, _ = getId(p, subdir)
 
 	if buf, err := os.ReadFile(path.Join(config.Config.MetadataPath, subdir, id+".json")); err != nil {
 		// First time reading metadata, create one
@@ -54,7 +57,7 @@ func ReadMetadata(p, etag string, subdir string) config.MetaFile {
 func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 	_ = os.MkdirAll(path.Join(config.Config.MetadataPath, subdir), 0755)
 
-	var id, filepath, sant = getId(p)
+	var id, filepath, sant = getId(p, subdir)
 
 	var data = config.MetaFile{
 		Id: id,
@@ -71,13 +74,9 @@ func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 	fmt.Println("p", p)
 	fmt.Println("getImageMeta(filepath)", filepath)
 
-	if config.ProxyMode {
+	imageMeta := getImageMeta(filepath)
 
-	} else {
-		imageMeta := getImageMeta(filepath)
-
-		data.ImageMeta = imageMeta
-	}
+	data.ImageMeta = imageMeta
 
 	buf, _ := json.Marshal(data)
 	_ = os.WriteFile(path.Join(config.Config.MetadataPath, subdir, data.Id+".json"), buf, 0644)
@@ -175,7 +174,7 @@ func getImageMeta(filePath string) (metadata config.ImageMeta) {
 }
 
 func DeleteMetadata(p string, subdir string) {
-	var id, _, _ = getId(p)
+	var id, _, _ = getId(p, subdir)
 	metadataPath := path.Join(config.Config.MetadataPath, subdir, id+".json")
 	err := os.Remove(metadataPath)
 	if err != nil {

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -67,8 +68,16 @@ func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 		data.Checksum = HashFile(filepath)
 	}
 
-	imageMeta := getImageMeta(filepath)
-	data.ImageMeta = imageMeta
+	fmt.Println("p", p)
+	fmt.Println("getImageMeta(filepath)", filepath)
+
+	if config.ProxyMode {
+
+	} else {
+		imageMeta := getImageMeta(filepath)
+
+		data.ImageMeta = imageMeta
+	}
 
 	buf, _ := json.Marshal(data)
 	_ = os.WriteFile(path.Join(config.Config.MetadataPath, subdir, data.Id+".json"), buf, 0644)

--- a/helper/metadata_test.go
+++ b/helper/metadata_test.go
@@ -13,7 +13,7 @@ func TestGetId(t *testing.T) {
 	t.Run("proxy mode", func(t *testing.T) {
 		// Test case 1: Proxy mode
 		config.ProxyMode = true
-		id, jointPath, santizedPath := getId(p)
+		id, jointPath, santizedPath := getId(p, "")
 
 		// Verify the return values
 		expectedId := HashString(p)
@@ -28,7 +28,7 @@ func TestGetId(t *testing.T) {
 		// Test case 2: Non-proxy mode
 		config.ProxyMode = false
 		p = "/image.jpg?width=400&height=500"
-		id, jointPath, santizedPath := getId(p)
+		id, jointPath, santizedPath := getId(p, "")
 
 		// Verify the return values
 		parsed, _ := url.Parse(p)

--- a/helper/metadata_test.go
+++ b/helper/metadata_test.go
@@ -17,7 +17,7 @@ func TestGetId(t *testing.T) {
 
 		// Verify the return values
 		expectedId := HashString(p)
-		expectedPath := ""
+		expectedPath := "remote-raw/8d8576343c4cb816.jpg?width=200&height=300"
 		expectedSantizedPath := ""
 		if id != expectedId || jointPath != expectedPath || santizedPath != expectedSantizedPath {
 			t.Errorf("Test case 1 failed: Expected (%s, %s, %s), but got (%s, %s, %s)",


### PR DESCRIPTION
This PR aims to fix the following bugs:
* https://github.com/webp-sh/webp_server_go/issues/383 caused by `path.Join` rather than `url.JoinPath`, making `https://xxxx/path/to/join` becoming `https:/xxx/path/to/join`
* https://github.com/webp-sh/webp_server_go/issues/392 caused by incomplete and junky metadata design.
* Tries to preserve remote file extension that will correctly render `Content-type` when using `"ALLOWED_TYPES": ["*"]` and fetching non-image from remote, related issue: https://github.com/webp-sh/webp_server_go/issues/388