### PR TITLE
add-tests-fix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ var (
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.13.4"
+	Version             = "0.13.5"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"

--- a/handler/router.go
+++ b/handler/router.go
@@ -113,7 +113,8 @@ func Convert(c *fiber.Ctx) error {
 
 		// Replace host in the URL
 		// realRemoteAddr = strings.Replace(reqURIwithQuery, reqHost, targetHost, 1)
-		realRemoteAddr, _ = url.JoinPath(targetHost, reqURIwithQuery)
+		realRemoteAddr = targetHost + reqURIwithQuery
+
 		log.Debugf("realRemoteAddr is %s", realRemoteAddr)
 	}
 

--- a/handler/router.go
+++ b/handler/router.go
@@ -109,13 +109,7 @@ func Convert(c *fiber.Ctx) error {
 			reqURIwithQuery = c.OriginalURL()
 		}
 
-		log.Tracef("reqURIwithQuery is %s", reqURIwithQuery)
-
-		// Replace host in the URL
-		// realRemoteAddr = strings.Replace(reqURIwithQuery, reqHost, targetHost, 1)
-		realRemoteAddr = targetHost + reqURIwithQuery
-
-		log.Debugf("realRemoteAddr is %s", realRemoteAddr)
+		realRemoteAddr = targetHost + "/" + reqURIwithQuery
 	}
 
 	// Check if the file extension is allowed and not with image extension

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -303,9 +303,16 @@ func TestConvertProxyModeNonImageWork(t *testing.T) {
 	var app = fiber.New()
 	app.Get("/*", Convert)
 
-	url := "http://127.0.0.1:3333/sw.js"
+	url := "http://127.0.0.1:3333/sw.js?version=13"
 
 	resp, _ := requestToServer(url, app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/javascript; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	url = "http://127.0.0.1:3333/sw.js"
+
+	resp, _ = requestToServer(url, app, chromeUA, acceptWebP)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "text/javascript; charset=utf-8", resp.Header.Get("Content-Type"))

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -70,9 +70,11 @@ func WriteMetadata(p, etag string, subdir string) config.MetaFile {
 		data.Checksum = HashFile(filepath)
 	}
 
-	imageMeta := getImageMeta(filepath)
-
-	data.ImageMeta = imageMeta
+	// Only get image metadata if the file has image extension
+	if CheckImageExtension(filepath) {
+		imageMeta := getImageMeta(filepath)
+		data.ImageMeta = imageMeta
+	}
 
 	buf, _ := json.Marshal(data)
 	_ = os.WriteFile(path.Join(config.Config.MetadataPath, subdir, data.Id+".json"), buf, 0644)


### PR DESCRIPTION
* Fix the way to concatenate remote backend, should fix https://github.com/webp-sh/webp_server_go/issues/383#issuecomment-2778011460 but might introduce vulnerabilities, need more tests on this.
* Only `CheckImageExtension` if downloaded file has image extension.