### PR TITLE
Do not resize image when ExtraParams Height/Width is larger than original image

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ var (
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.14.0"
+	Version             = "0.14.1"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"

--- a/encoder/process.go
+++ b/encoder/process.go
@@ -24,6 +24,11 @@ func resizeImage(img *vips.ImageRef, extraParams config.ExtraParams) error {
 	// e.g, 500x500px image with max_width=200,max_height=100 will be resized to 100x100
 	// while smaller images are untouched
 
+	// If width or max is set and larger than original image, don't resize
+	if extraParams.Width > imageWidth || extraParams.Height > imageHeight {
+		return nil
+	}
+
 	// If both are used, we will use width and height
 
 	if extraParams.MaxHeight > 0 && extraParams.MaxWidth > 0 {

--- a/encoder/process_test.go
+++ b/encoder/process_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestResizeImage(t *testing.T) {
-	img, _ := vips.Black(500, 500)
 
 	// Define the parameters for the test cases
 	testCases := []struct {
@@ -60,21 +59,33 @@ func TestResizeImage(t *testing.T) {
 				Width:  200,
 				Height: 200,
 			},
-			expectedH: 200,
 			expectedW: 200,
+			expectedH: 200,
 		},
 		{
 			extraParams: config.ExtraParams{
 				Width:  200,
 				Height: 500,
 			},
-			expectedH: 500,
 			expectedW: 200,
+			expectedH: 500,
+		},
+
+		// Test for Width and Height larger than original image, should not resize
+		{
+			extraParams: config.ExtraParams{
+				Width:  600,
+				Height: 600,
+			},
+			expectedH: 500,
+			expectedW: 500,
 		},
 	}
 
 	// Iterate through the test cases and perform the tests
 	for _, tc := range testCases {
+		img, _ := vips.Black(500, 500)
+		defer img.Close()
 		err := resizeImage(img, tc.extraParams)
 		if err != nil {
 			t.Errorf("resizeImage failed with error: %v", err)


### PR DESCRIPTION
Should fix:
* https://github.com/webp-sh/webp_server_go/issues/421
* https://github.com/webp-sh/webp_server_go/issues/423