### PR TITLE
Harden path handling, enforce strict `meta` checks, and remove `ProxyMode`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security Policy
+
+## Supported Versions
+
+We do not maintain long-term support for individual releases. Security fixes are included in the next published version only; we do not backport fixes to older releases.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
+
+Check [Releases](https://github.com/webp-sh/webp_server_go/releases) for the current version and upgrade when a security fix is published.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+If you believe you have found a security issue in WebP Server Go, report it privately so we can investigate and release a fix before details are disclosed publicly.
+
+### Preferred: GitHub Private Security Advisory
+
+Use [GitHub Security Advisories](https://github.com/webp-sh/webp_server_go/security/advisories/new) to submit a private report. This is the fastest way for maintainers to receive, track, and coordinate a fix.
+
+### What to Include
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce, including request examples, configuration, or proof-of-concept if available
+- Affected version(s) or commit hash
+- Any suggested mitigation or fix, if you have one
+
+### Response Timeline
+
+We aim to:
+
+- Acknowledge your report within **3 business days**
+- Provide an initial assessment within **7 business days**
+- Keep you informed as we work on a fix and coordinated disclosure
+
+Timelines may vary for complex issues or during holidays; we will communicate delays when they occur.
+
+### Disclosure
+
+We follow coordinated disclosure. Please allow reasonable time for a fix before public disclosure. We will credit reporters in the advisory when they wish to be acknowledged.
+
+## Scope
+
+The following are generally **in scope**:
+
+- Remote code execution, authentication bypass, or privilege escalation in WebP Server Go
+- Path traversal or unauthorized file access via HTTP requests
+- Server-side request forgery (SSRF) or unsafe remote fetching in proxy/remote modes
+- Denial of service that can be triggered remotely with minimal resources
+- Memory safety or parser issues in image processing that lead to exploitable conditions
+
+The following are generally **out of scope**:
+
+- Issues in third-party dependencies already tracked upstream (please still report if the project is affected and we have not patched)
+- Vulnerabilities in your reverse proxy, container runtime, or host OS configuration
+- Missing security headers or TLS configuration on your deployment (see deployment guidance below)
+- Social engineering or physical access attacks
+
+## Deployment Guidance
+
+WebP Server Go is an HTTP image conversion service. Secure deployment is shared responsibility between the software and operators.
+
+We recommend:
+
+- **Bind locally by default** — keep `HOST` at `127.0.0.1` and expose the service through a reverse proxy (Nginx, Caddy, etc.), as shown in the [README](./README.md).
+- **Use Docker** — our maintained images are scanned in CI; upgrade to the latest release when security fixes are published.
+- **Limit exposed surface** — restrict `ALLOWED_TYPES`, disable unused features (`ENABLE_EXTRA_PARAMS`, remote/proxy modes) when not required.
+- **Protect origin paths** — ensure `IMG_PATH` and cache directories are not writable by untrusted users.
+- **Review `IMG_MAP` / remote sources** — proxy and remote modes fetch URLs; only map to trusted origins to reduce SSRF risk.
+- **Keep dependencies current** — rebuild or pull new images after security releases.
+
+## Security Practices in This Repository
+
+- Static analysis with [CodeQL](https://github.com/webp-sh/webp_server_go/actions/workflows/codeql-analysis.yml)
+- Container image scanning with Trivy in [CI](https://github.com/webp-sh/webp_server_go/actions/workflows/CI.yaml)
+- Dependency updates via [Dependabot](https://github.com/webp-sh/webp_server_go/blob/master/.github/dependabot.yml)
+
+Thank you for helping keep WebP Server Go and its users safe.

--- a/config/config.go
+++ b/config/config.go
@@ -49,13 +49,12 @@ var (
 	DumpSystemd         bool
 	DumpConfig          bool
 	ShowVersion         bool
-	ProxyMode           bool
 	AllowAllExtensions  bool
 	Prefetch            bool // Prefech in go-routine, with WebP Server Go launch normally
 	PrefetchForeground  bool // Standalone prefetch, prefetch and exit
 	AllowNonImage       bool
 	Config              = NewWebPConfig()
-	Version             = "0.14.4"
+	Version             = "0.15.0"
 	WriteLock           = cache.New(5*time.Minute, 10*time.Minute)
 	ConvertLock         = cache.New(5*time.Minute, 10*time.Minute)
 	LocalHostAlias      = "local"
@@ -219,30 +218,45 @@ func LoadConfig() {
 
 	if os.Getenv("WEBP_ENABLE_EXTRA_PARAMS") != "" {
 		enableExtraParams := os.Getenv("WEBP_ENABLE_EXTRA_PARAMS")
-		if enableExtraParams == "true" {
+		switch enableExtraParams {
+		case "true":
 			Config.EnableExtraParams = true
-		} else if enableExtraParams == "false" {
+		case "false":
 			Config.EnableExtraParams = false
-		} else {
+		default:
 			log.Warnf("WEBP_ENABLE_EXTRA_PARAMS is not a valid boolean, using value in config.json %t", Config.EnableExtraParams)
 		}
 	}
 	if os.Getenv("WEBP_EXTRA_PARAMS_CROP_INTERESTING") != "" {
-		availableInteresting := []string{"InterestingNone", "InterestingEntropy", "InterestingCentre", "InterestingAttention", "InterestringLow", "InterestingHigh", "InterestingAll"}
-		if slices.Contains(availableInteresting, os.Getenv("WEBP_EXTRA_PARAMS_CROP_INTERESTING")) {
-			Config.ExtraParamsCropInteresting = os.Getenv("WEBP_EXTRA_PARAMS_CROP_INTERESTING")
-		} else {
+		cropInteresting := os.Getenv("WEBP_EXTRA_PARAMS_CROP_INTERESTING")
+		switch cropInteresting {
+		case "InterestingNone":
+			Config.ExtraParamsCropInteresting = "InterestingNone"
+		case "InterestingEntropy":
+			Config.ExtraParamsCropInteresting = "InterestingEntropy"
+		case "InterestingCentre":
+			Config.ExtraParamsCropInteresting = "InterestingCentre"
+		case "InterestingAttention":
+			Config.ExtraParamsCropInteresting = "InterestingAttention"
+		case "InterestingLow":
+			Config.ExtraParamsCropInteresting = "InterestingLow"
+		case "InterestingHigh":
+			Config.ExtraParamsCropInteresting = "InterestingHigh"
+		case "InterestingAll":
+			Config.ExtraParamsCropInteresting = "InterestingAll"
+		default:
 			log.Warnf("WEBP_EXTRA_PARAMS_CROP_INTERESTING is not a valid interesting, using value in config.json %s", Config.ExtraParamsCropInteresting)
 		}
 	}
 
 	if os.Getenv("WEBP_STRIP_METADATA") != "" {
 		stripMetadata := os.Getenv("WEBP_STRIP_METADATA")
-		if stripMetadata == "true" {
+		switch stripMetadata {
+		case "true":
 			Config.StripMetadata = true
-		} else if stripMetadata == "false" {
+		case "false":
 			Config.StripMetadata = false
-		} else {
+		default:
 			log.Warnf("WEBP_STRIP_METADATA is not a valid boolean, using value in config.json %t", Config.StripMetadata)
 		}
 	}
@@ -267,11 +281,12 @@ func LoadConfig() {
 	}
 	if os.Getenv("WEBP_DISABLE_KEEPALIVE") != "" {
 		disableKeepalive := os.Getenv("WEBP_DISABLE_KEEPALIVE")
-		if disableKeepalive == "true" {
+		switch disableKeepalive {
+		case "true":
 			Config.DisableKeepalive = true
-		} else if disableKeepalive == "false" {
+		case "false":
 			Config.DisableKeepalive = false
-		} else {
+		default:
 			log.Warnf("WEBP_DISABLE_KEEPALIVE is not a valid boolean, using value in config.json %t", Config.DisableKeepalive)
 		}
 	}
@@ -302,7 +317,6 @@ func LoadConfig() {
 	if Config.AllowedTypes[0] == "*" {
 		AllowAllExtensions = true
 	}
-	switchProxyMode()
 	Config.ImageMap = parseImgMap(Config.ImageMap)
 
 	log.Debugln("Config init complete")
@@ -329,13 +343,4 @@ type ExtraParams struct {
 	Height    int // in px
 	MaxWidth  int // in px
 	MaxHeight int // in px
-}
-
-func switchProxyMode() {
-	matched, _ := regexp.MatchString(HttpRegexp, Config.ImgPath)
-	if matched {
-		// Enable proxy based on ImgPath should be deprecated in future versions
-		log.Warn("Enable proxy based on ImgPath will be deprecated in future versions. Use IMG_MAP config options instead")
-		ProxyMode = true
-	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,14 +25,6 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, Config.MaxCacheSize, 0)
 }
 
-func TestSwitchProxyMode(t *testing.T) {
-	switchProxyMode()
-	assert.False(t, ProxyMode)
-	Config.ImgPath = "https://picsum.photos"
-	switchProxyMode()
-	assert.True(t, ProxyMode)
-}
-
 func TestParseImgMap(t *testing.T) {
 	empty := map[string]string{}
 	good := map[string]string{

--- a/handler/router.go
+++ b/handler/router.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"net/http"
 	"net/url"
-	"regexp"
 	"slices"
 	"strings"
 	"webp_server_go/config"
@@ -23,10 +22,11 @@ func Convert(c *fiber.Ctx) error {
 	// 2. generate rawImagePath, could be local path or remote url(possible with query string)
 	// 3. pass it to encoder, get the result, send it back
 
-	// normal http request will start with /
-	if !strings.HasPrefix(c.Path(), "/") {
-		_ = c.SendStatus(http.StatusBadRequest)
-		return nil
+	requestPath := c.Path()
+	requestPathDecoded, _ := url.QueryUnescape(requestPath)
+	// For invalid or traversal-like paths, always return 404.
+	if !strings.HasPrefix(requestPath, "/") || hasTraversalSegments(requestPathDecoded) {
+		return sendNotFound(c)
 	}
 
 	var (
@@ -39,12 +39,7 @@ func Convert(c *fiber.Ctx) error {
 		reqURI                = path.Clean(reqURIRaw)              // delete ../ in reqURI to mitigate directory traversal
 		reqURIwithQuery       = path.Clean(reqURIwithQueryRaw)     // Sometimes reqURIwithQuery can be https://example.tld/mypic/123.jpg?someother=200&somebugs=200, we need to extract it
 
-		filename       = path.Base(reqURI)
-		realRemoteAddr = ""
-		targetHostName = config.LocalHostAlias
-		targetHost     = config.Config.ImgPath
-		proxyMode      = config.ProxyMode
-		mapMode        = false
+		filename = path.Base(reqURI)
 
 		meta = c.Query("meta") // Meta request
 
@@ -70,88 +65,73 @@ func Convert(c *fiber.Ctx) error {
 		return nil
 	}
 
-	// Rewrite the target backend if a mapping rule matches the hostname
-	if hostMap, hostMapFound := config.Config.ImageMap[reqHost]; hostMapFound {
-		log.Debugf("Found host mapping %s -> %s", reqHostname, hostMap)
-		targetHostUrl, _ := url.Parse(hostMap)
-		targetHostName = targetHostUrl.Host
-		targetHost = targetHostUrl.Scheme + "://" + targetHostUrl.Host
-		proxyMode = true
-	} else {
-		// There's not matching host mapping, now check for any URI map that apply
-		httpRegexpMatcher := regexp.MustCompile(config.HttpRegexp)
-		for uriMap, uriMapTarget := range config.Config.ImageMap {
-			if strings.HasPrefix(reqURI, uriMap) {
-				log.Debugf("Found URI mapping %s -> %s", uriMap, uriMapTarget)
-				mapMode = true
+	state := requestState{
+		mode:            requestModeLocalDefault,
+		reqURI:          reqURI,
+		reqURIWithQuery: reqURIwithQuery,
+		targetHostName:  config.LocalHostAlias,
+		targetHost:      config.Config.ImgPath,
+	}
+	if isRemoteTarget(config.Config.ImgPath) {
+		state.mode = requestModeRemoteDefault
+	}
+	resolveRequestState(reqHost, reqHostname, &state)
 
-				// if uriMapTarget we use the proxy mode to fetch the remote
-				if httpRegexpMatcher.Match([]byte(uriMapTarget)) {
-					targetHostUrl, _ := url.Parse(uriMapTarget)
-					targetHostName = targetHostUrl.Host
-					targetHost = targetHostUrl.Scheme + "://" + targetHostUrl.Host
-					reqURI = strings.Replace(reqURI, uriMap, targetHostUrl.Path, 1)
-					reqURIwithQuery = strings.Replace(reqURIwithQuery, uriMap, targetHostUrl.Path, 1)
-					proxyMode = true
-				} else {
-					reqURI = strings.Replace(reqURI, uriMap, uriMapTarget, 1)
-					reqURIwithQuery = strings.Replace(reqURIwithQuery, uriMap, uriMapTarget, 1)
-				}
-				break
-			}
-		}
+	if state.mode == requestModeRemoteDefault {
+		// Don't deal with the encoding to avoid upstream compatibilities
+		state.reqURI = c.Path()
+		state.reqURIWithQuery = c.OriginalURL()
 	}
 
-	if proxyMode {
-		if !mapMode {
-			// Don't deal with the encoding to avoid upstream compatibilities
-			reqURI = c.Path()
-			reqURIwithQuery = c.OriginalURL()
-		}
-
+	if state.isRemote() {
 		// Remove first leading slash from reqURIwithQuery if present
-		if strings.HasPrefix(reqURIwithQuery, "/") {
-			reqURIwithQuery = reqURIwithQuery[1:]
-		}
-		realRemoteAddr = targetHost + "/" + reqURIwithQuery
+		state.reqURIWithQuery = strings.TrimPrefix(state.reqURIWithQuery, "/")
+		state.realRemoteAddr = state.targetHost + "/" + state.reqURIWithQuery
 	}
 
 	// Check if the file extension is allowed and not with image extension
 	// In this case we will serve the file directly
 	// Since here we've already sent non-image file, "raw" is not supported by default in the following code
 	if config.AllowAllExtensions && !helper.CheckImageExtension(filename) {
-		if !proxyMode {
-			return c.SendFile(path.Join(config.Config.ImgPath, reqURI))
+		if !state.isRemote() {
+			localFilename, err := resolveLocalRequestPath(state)
+			if err != nil {
+				return sendNotFound(c)
+			}
+			return c.SendFile(localFilename)
 		} else {
 			// If the file is not in the ImgPath, we'll have to use the proxy mode to download it
-			_ = fetchRemoteImg(realRemoteAddr, targetHostName)
-			localFilename := path.Join(config.Config.RemoteRawPath, targetHostName, helper.HashString(realRemoteAddr)) + path.Ext(realRemoteAddr)
+			_ = fetchRemoteImg(state.realRemoteAddr, state.targetHostName)
+			localFilename := path.Join(config.Config.RemoteRawPath, state.targetHostName, helper.HashString(state.realRemoteAddr)) + path.Ext(state.realRemoteAddr)
 			return c.SendFile(localFilename)
 		}
 	}
 
 	var rawImageAbs string
 	var metadata = config.MetaFile{}
-	if proxyMode {
-		// this is proxyMode, we'll have to use this url to download and save it to local path, which also gives us rawImageAbs
+	if state.isRemote() {
+		// this is remote mode, we'll have to use this url to download and save it to local path, which also gives us rawImageAbs
 		// https://test.webp.sh/mypic/123.jpg?someother=200&somebugs=200
 
-		metadata = fetchRemoteImg(realRemoteAddr, targetHostName)
-		rawImageAbs = path.Join(config.Config.RemoteRawPath, targetHostName, metadata.Id) + path.Ext(realRemoteAddr)
+		metadata = fetchRemoteImg(state.realRemoteAddr, state.targetHostName)
+		rawImageAbs = path.Join(config.Config.RemoteRawPath, state.targetHostName, metadata.Id) + path.Ext(state.realRemoteAddr)
 	} else {
-		// not proxyMode, we'll use local path
-		metadata = helper.ReadMetadata(reqURIwithQuery, "", targetHostName)
-		if !mapMode {
-			// by default images are hosted in ImgPath
-			rawImageAbs = path.Join(config.Config.ImgPath, reqURI)
-		} else {
-			rawImageAbs = reqURI
-		}
+		rawImageAbs, _ = resolveLocalRequestPath(state)
+	}
+
+	// Check the original image for existence,
+	if rawImageAbs == "" || !helper.ImageExists(rawImageAbs) {
+		helper.DeleteMetadata(state.reqURIWithQuery, state.targetHostName)
+		return sendNotFound(c)
+	}
+
+	if !state.isRemote() {
+		metadata = helper.ReadMetadata(state.reqURIWithQuery, "", state.targetHostName)
 		// detect if source file has changed
 		if metadata.Checksum != helper.HashFile(rawImageAbs) {
 			log.Info("Source file has changed, re-encoding...")
-			helper.WriteMetadata(reqURIwithQuery, "", targetHostName)
-			cleanProxyCache(path.Join(config.Config.ExhaustPath, targetHostName, metadata.Id))
+			metadata = helper.WriteMetadata(state.reqURIWithQuery, "", state.targetHostName)
+			cleanProxyCache(path.Join(config.Config.ExhaustPath, state.targetHostName, metadata.Id))
 		}
 	}
 
@@ -178,24 +158,14 @@ func Convert(c *fiber.Ctx) error {
 		supportedFormats["avif"] == false &&
 		supportedFormats["jxl"] == false &&
 		supportedFormats["heic"] == false {
-		dest := path.Join(config.Config.ExhaustPath, targetHostName, metadata.Id)
+		dest := path.Join(config.Config.ExhaustPath, state.targetHostName, metadata.Id)
 		if !helper.ImageExists(dest) {
 			encoder.ResizeItself(rawImageAbs, dest, extraParams)
 		}
 		return c.SendFile(dest)
 	}
 
-	// Check the original image for existence,
-	if !helper.ImageExists(rawImageAbs) {
-		helper.DeleteMetadata(reqURIwithQuery, targetHostName)
-		msg := "Image not found!"
-		_ = c.Send([]byte(msg))
-		log.Warn(msg)
-		_ = c.SendStatus(404)
-		return nil
-	}
-
-	avifAbs, webpAbs, jxlAbs := helper.GenOptimizedAbsPath(metadata, targetHostName)
+	avifAbs, webpAbs, jxlAbs := helper.GenOptimizedAbsPath(metadata, state.targetHostName)
 	// Do the convertion based on supported formats and config
 	encoder.ConvertFilter(rawImageAbs, jxlAbs, avifAbs, webpAbs, extraParams, supportedFormats, nil)
 

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -35,11 +35,11 @@ func setupParam() {
 	config.Config.AllowedTypes = []string{"jpg", "png", "jpeg", "bmp", "heic", "avif"}
 	config.Config.MetadataPath = "../metadata"
 	config.Config.RemoteRawPath = "../remote-raw"
-	config.ProxyMode = false
 	config.Config.EnableWebP = true
 	config.Config.EnableAVIF = false
 	config.Config.Quality = 80
 	config.Config.ImageMap = map[string]string{}
+	config.AllowAllExtensions = false
 	config.RemoteCache = cache.New(cache.NoExpiration, 10*time.Minute)
 }
 
@@ -50,6 +50,36 @@ func requestToServer(reqUrl string, app *fiber.App, ua, accept string) (*http.Re
 	req.Header.Set("Accept", accept)
 	req.Header.Set("Host", parsedUrl.Host)
 	req.Host = parsedUrl.Host
+	resp, err := app.Test(req, 120000)
+	if err != nil {
+		return nil, nil
+	}
+	data, _ := io.ReadAll(resp.Body)
+	return resp, data
+}
+
+func requestRawPathToServer(rawPath string, host string, app *fiber.App, ua, accept string) (*http.Response, []byte) {
+	req := httptest.NewRequest("GET", rawPath, nil)
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("Host", host)
+	req.Host = host
+	resp, err := app.Test(req, 120000)
+	if err != nil {
+		return nil, nil
+	}
+	data, _ := io.ReadAll(resp.Body)
+	return resp, data
+}
+
+func requestMalformedPathToServer(rawPath string, host string, app *fiber.App, ua, accept string) (*http.Response, []byte) {
+	req := httptest.NewRequest("GET", "http://"+host+"/", nil)
+	req.URL.Path = rawPath
+	req.RequestURI = rawPath
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("Host", host)
+	req.Host = host
 	resp, err := app.Test(req, 120000)
 	if err != nil {
 		return nil, nil
@@ -229,11 +259,79 @@ func TestConvertPassThrough(t *testing.T) {
 	assert.Contains(t, string(data), "HOST")
 }
 
+func TestConvertPathTraversalBlocked(t *testing.T) {
+	setupParam()
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	cases := []string{
+		"/../config.json",
+		"/../../config.json",
+		"/%2e%2e%2fconfig.json",
+		"/%252e%252e%252fconfig.json",
+	}
+
+	for _, requestPath := range cases {
+		resp, data := requestRawPathToServer(requestPath, "127.0.0.1:3333", app, chromeUA, acceptWebP)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, requestPath)
+		assert.NotContains(t, string(data), "HOST", requestPath)
+	}
+}
+
+func TestConvertMalformedPathReturnsNotFound(t *testing.T) {
+	setupParam()
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	resp, _ := requestMalformedPathToServer("webp_server.jpg", "127.0.0.1:3333", app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestConvertMetaRequestRequiresExistingImage(t *testing.T) {
+	setupParam()
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	resp, _ := requestRawPathToServer("/%252e%252e%252f%252e%252e%252fDesktop/4951333.png?meta=full", "127.0.0.1:3333", app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestConvertPassThroughBlocksTraversal(t *testing.T) {
+	setupParam()
+	config.Config.AllowedTypes = []string{"*"}
+	config.AllowAllExtensions = true
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	resp, data := requestRawPathToServer("/../config.json", "127.0.0.1:3333", app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.NotContains(t, string(data), "HOST")
+}
+
+func TestConvertEncodedUnicodeFilenameStillWorks(t *testing.T) {
+	setupParam()
+
+	var app = fiber.New()
+	app.Get("/*", Convert)
+
+	resp, data := requestRawPathToServer("/%e5%a4%aa%e7%a5%9e%e5%95%a6.png", "127.0.0.1:3333", app, chromeUA, acceptWebP)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/webp", helper.GetContentType(data))
+}
+
 func TestConvertPassThroughWithRemoteBackend(t *testing.T) {
 	setupParam()
 	config.Config.AllowedTypes = []string{"*"}
 	config.Config.ImgPath = "https://docs.webp.sh"
-	config.ProxyMode = true
 	config.AllowAllExtensions = true
 
 	var app = fiber.New()
@@ -253,7 +351,7 @@ func TestConvertPassThroughWithRemoteBackend(t *testing.T) {
 
 func TestConvertProxyModeBad(t *testing.T) {
 	setupParam()
-	config.ProxyMode = true
+	config.Config.ImgPath = "https://docs.webp.sh"
 
 	var app = fiber.New()
 	app.Get("/*", Convert)
@@ -273,7 +371,6 @@ func TestConvertProxyModeBad(t *testing.T) {
 
 func TestConvertProxyModeWork(t *testing.T) {
 	setupParam()
-	config.ProxyMode = true
 	config.Config.ImgPath = "https://docs.webp.sh"
 
 	var app = fiber.New()
@@ -295,7 +392,6 @@ func TestConvertProxyModeWork(t *testing.T) {
 
 func TestConvertProxyModeNonImageWork(t *testing.T) {
 	setupParam()
-	config.ProxyMode = true
 	config.Config.AllowedTypes = []string{"*"}
 	config.AllowAllExtensions = true
 	config.Config.ImgPath = "https://docs.webp.sh"
@@ -320,7 +416,6 @@ func TestConvertProxyModeNonImageWork(t *testing.T) {
 
 func TestConvertMapProxyModeWork(t *testing.T) {
 	setupParam()
-	config.ProxyMode = true
 	config.Config.ImageMap = map[string]string{
 		"/": "https://docs.webp.sh",
 	}
@@ -344,7 +439,6 @@ func TestConvertMapProxyModeWork(t *testing.T) {
 
 func TestConvertProxyImgMap(t *testing.T) {
 	setupParam()
-	config.ProxyMode = false
 	config.Config.ImageMap = map[string]string{
 		"/2":                            "../pics/dir1",
 		"/3":                            "../pics3",                 // Invalid path, does not exists
@@ -404,7 +498,6 @@ func TestConvertProxyImgMap(t *testing.T) {
 
 func TestConvertProxyImgMapCWD(t *testing.T) {
 	setupParam()
-	config.ProxyMode = false
 	config.Config.ImgPath = ".." // equivalent to "" when not testing
 	config.Config.ImageMap = map[string]string{
 		"/1":                     "../pics/dir1",

--- a/handler/state.go
+++ b/handler/state.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+	"webp_server_go/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type requestMode string
+
+const (
+	requestModeLocalDefault  requestMode = "local_default"
+	requestModeLocalMapped   requestMode = "local_mapped"
+	requestModeRemoteDefault requestMode = "remote_default"
+	requestModeRemoteMapped  requestMode = "remote_mapped"
+)
+
+type requestState struct {
+	mode            requestMode
+	reqURI          string
+	reqURIWithQuery string
+	targetHostName  string
+	targetHost      string
+	mapLocalBase    string
+	realRemoteAddr  string
+}
+
+func (r requestState) isRemote() bool {
+	return r.mode == requestModeRemoteDefault || r.mode == requestModeRemoteMapped
+}
+
+func (r requestState) isLocalMapped() bool {
+	return r.mode == requestModeLocalMapped
+}
+
+func resolveRequestState(reqHost string, reqHostname string, state *requestState) {
+	// Rewrite the target backend if a mapping rule matches the hostname
+	if hostMap, hostMapFound := config.Config.ImageMap[reqHost]; hostMapFound {
+		log.Debugf("Found host mapping %s -> %s", reqHostname, hostMap)
+		targetHostURL, _ := url.Parse(hostMap)
+		state.targetHostName = targetHostURL.Host
+		state.targetHost = targetHostURL.Scheme + "://" + targetHostURL.Host
+		state.mode = requestModeRemoteDefault
+		return
+	}
+
+	// There's no matching host mapping, now check for any URI map that applies
+	httpRegexpMatcher := regexp.MustCompile(config.HttpRegexp)
+	for uriMap, uriMapTarget := range config.Config.ImageMap {
+		if strings.HasPrefix(state.reqURI, uriMap) {
+			log.Debugf("Found URI mapping %s -> %s", uriMap, uriMapTarget)
+
+			// if uriMapTarget is URL, use remote mode to fetch upstream.
+			if httpRegexpMatcher.Match([]byte(uriMapTarget)) {
+				targetHostURL, _ := url.Parse(uriMapTarget)
+				state.targetHostName = targetHostURL.Host
+				state.targetHost = targetHostURL.Scheme + "://" + targetHostURL.Host
+				state.reqURI = strings.Replace(state.reqURI, uriMap, targetHostURL.Path, 1)
+				state.reqURIWithQuery = strings.Replace(state.reqURIWithQuery, uriMap, targetHostURL.Path, 1)
+				state.mode = requestModeRemoteMapped
+			} else {
+				state.mapLocalBase = uriMapTarget
+				state.reqURI = strings.Replace(state.reqURI, uriMap, uriMapTarget, 1)
+				state.reqURIWithQuery = strings.Replace(state.reqURIWithQuery, uriMap, uriMapTarget, 1)
+				state.mode = requestModeLocalMapped
+			}
+			return
+		}
+	}
+}
+
+func resolveLocalRequestPath(state requestState) (string, error) {
+	if state.isLocalMapped() {
+		return resolveSafeMappedPath(state.mapLocalBase, state.reqURI)
+	}
+	return resolveSafeLocalPath(config.Config.ImgPath, state.reqURI)
+}
+
+func isRemoteTarget(target string) bool {
+	httpRegexpMatcher := regexp.MustCompile(config.HttpRegexp)
+	return httpRegexpMatcher.MatchString(target)
+}

--- a/handler/utils.go
+++ b/handler/utils.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+func sendNotFound(c *fiber.Ctx) error {
+	msg := "Image not found!"
+	_ = c.Send([]byte(msg))
+	log.Warn(msg)
+	_ = c.SendStatus(404)
+	return nil
+}
+
+func resolveSafeLocalPath(baseDir string, reqPath string) (string, error) {
+	decoded, err := url.PathUnescape(reqPath)
+	if err != nil {
+		return "", err
+	}
+	if hasTraversalSegments(decoded) {
+		return "", fiber.ErrNotFound
+	}
+	cleaned := path.Clean("/" + decoded)
+	relative := strings.TrimPrefix(cleaned, "/")
+	candidate := filepath.Join(baseDir, filepath.FromSlash(relative))
+	return ensurePathWithinBase(baseDir, candidate)
+}
+
+func resolveSafeMappedPath(baseDir string, reqPath string) (string, error) {
+	if baseDir == "" {
+		return "", fiber.ErrNotFound
+	}
+	decoded, err := url.PathUnescape(reqPath)
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Clean(filepath.FromSlash(decoded))
+	return ensurePathWithinBase(baseDir, candidate)
+}
+
+func ensurePathWithinBase(baseDir string, candidate string) (string, error) {
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", err
+	}
+	candidateAbs, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(baseAbs, candidateAbs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fiber.ErrNotFound
+	}
+	return candidateAbs, nil
+}
+
+func hasTraversalSegments(pathValue string) bool {
+	decoded, err := url.PathUnescape(pathValue)
+	if err == nil {
+		pathValue = decoded
+	}
+	pathValue = strings.ReplaceAll(pathValue, "\\", "/")
+	for _, segment := range strings.Split(pathValue, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/helper/metadata.go
+++ b/helper/metadata.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"webp_server_go/config"
 
 	"github.com/buckket/go-blurhash"
@@ -13,9 +14,10 @@ import (
 )
 
 // Get ID and filepath
-// For ProxyMode, pass in p the remote-raw path
+// For remote URLs, metadata id is generated from full URL.
 func getId(p string, subdir string) (id string, filePath string, santizedPath string) {
-	if config.ProxyMode {
+	httpRegexpMatcher := regexp.MustCompile(config.HttpRegexp)
+	if httpRegexpMatcher.MatchString(p) {
 		fileID := HashString(p)
 		return fileID, path.Join(config.Config.RemoteRawPath, subdir, fileID) + path.Ext(p), ""
 	}

--- a/helper/metadata_test.go
+++ b/helper/metadata_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 func TestGetId(t *testing.T) {
+	config.Config.ImgPath = "./pics"
+	config.Config.RemoteRawPath = "remote-raw"
 	p := "https://example.com/image.jpg?width=200&height=300"
 
-	t.Run("proxy mode", func(t *testing.T) {
-		// Test case 1: Proxy mode
-		config.ProxyMode = true
+	t.Run("remote url", func(t *testing.T) {
+		// Test case 1: Remote URL
 		id, jointPath, santizedPath := getId(p, "")
 
 		// Verify the return values
@@ -24,9 +25,8 @@ func TestGetId(t *testing.T) {
 				expectedId, expectedPath, expectedSantizedPath, id, jointPath, santizedPath)
 		}
 	})
-	t.Run("non-proxy mode", func(t *testing.T) {
-		// Test case 2: Non-proxy mode
-		config.ProxyMode = false
+	t.Run("local path", func(t *testing.T) {
+		// Test case 2: Local path
 		p = "/image.jpg?width=400&height=500"
 		id, jointPath, santizedPath := getId(p, "")
 


### PR DESCRIPTION
## Summary

- Hardened request path validation to block traversal attempts (including encoded and double-encoded variants) and return `404` consistently for invalid/traversal-like paths.
- Moved local file resolution to centralized safe path helpers and applied the same boundary checks to normal image flow and `AllowAllExtensions` passthrough flow.
- Changed `meta=full` behavior to be strict: metadata is returned only when the source image path is valid and the source file exists; otherwise returns `404`.
- Refactored routing mode handling into an explicit request state machine for clearer local/remote and mapped/default behavior.
- Removed global `ProxyMode` configuration and related switching logic; remote behavior is now inferred from URL-based targets (`IMG_PATH`/`IMG_MAP`).
- Updated metadata ID/filepath resolution to infer remote/local from input path shape instead of global mode flags.
- Added/updated tests to cover traversal blocking, malformed paths, strict `meta=full`, passthrough traversal protection, and URL-encoded filename compatibility.

## Why

This change closes traversal-related attack paths (including multi-encoding cases), eliminates inconsistent status behavior for malformed inputs, and prevents stale/unsafe metadata responses for non-existent or invalid targets.  
It also simplifies long-term routing behavior by removing `ProxyMode` and making source resolution explicit and predictable.

## Behavioral Changes

- Invalid and traversal-like request paths now consistently return `404`.
- `?meta=full` now returns `404` when the target path is invalid or source file is missing.
- `ProxyMode` is removed; remote source handling is determined by URL-based target configuration.